### PR TITLE
fix: preserve landing panel opacity on desktop

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -153,6 +153,7 @@ img {
 
 .panel-card.landing-panel {
   background: rgba(9, 12, 16, 0.8);
+  opacity: 0.8;
 }
 
 .landing-panel__stack,
@@ -228,6 +229,12 @@ h2 {
 p {
   color: var(--site-muted);
   line-height: 1.65;
+}
+
+@media (min-width: 901px) {
+  .landing-panel {
+    align-content: start;
+  }
 }
 
 @media (max-width: 900px) {

--- a/apps/web/src/app/globals.test.ts
+++ b/apps/web/src/app/globals.test.ts
@@ -6,7 +6,10 @@ describe("globals.css contract", () => {
     const css = readFileSync(new URL("./globals.css", import.meta.url), "utf8");
 
     expect(css).toMatch(
-      /\.panel-card\.landing-panel\s*\{[\s\S]*?background:\s*rgba\(9, 12, 16, 0\.8\);[\s\S]*?\}/
+      /\.panel-card\.landing-panel\s*\{[\s\S]*?background:\s*rgba\(9, 12, 16, 0\.8\);[\s\S]*?opacity:\s*0\.8;[\s\S]*?\}/
+    );
+    expect(css).toMatch(
+      /@media\s*\(min-width:\s*901px\)\s*\{[\s\S]*?\.landing-panel\s*\{[\s\S]*?align-content:\s*start;[\s\S]*?\}[\s\S]*?\}/
     );
     expect(css).toMatch(
       /\.atmos-link\s*\{[\s\S]*?border-radius:\s*1rem;[\s\S]*?\}/


### PR DESCRIPTION
## Summary
- keep `.panel-card.landing-panel` at opacity 0.8 instead of relying only on the background alpha
- pin desktop landing panel layout with `align-content: start` so the aside does not stretch awkwardly
- extend the CSS contract test to guard both rules against regression

## Test Plan
- `pnpm test`
- `pnpm typecheck`
- `pnpm -r run build`
- `pnpm --filter @raid/web run cf:build`
- `pnpm --filter @raid/web exec wrangler d1 migrations list raid-sl-clan --local`
