### PR TITLE
docs: sync repo status and add mobile-first clan dashboard design

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Raid SL Clan Knowledge Base
 
 This file is a working knowledge base for agents and humans operating in this repository.
-It reflects repository state as of 2026-04-26 and should be corrected when code and docs drift.
+It reflects repository state as of 2026-05-03 and should be corrected when code and docs drift.
 
 ## Current Snapshot
 
@@ -11,6 +11,8 @@ It reflects repository state as of 2026-04-26 and should be corrected when code 
 - Runtime model: public website plus Telegram webhook served from the same Cloudflare deployment.
 - Internal package boundaries exist in `packages/core`, `packages/application`, `packages/ports`, and `packages/platform`.
 - Repository-owned D1 migrations live in `platform/migrations`.
+- D1 schema migrations `0001_bootstrap.sql` and `0002_clan_competition_schema.sql` are applied for local development and the remote production database.
+- Remote preview D1 is currently not maintained as a required baseline and may intentionally lag behind production schema.
 - `pnpm typecheck` passes across the current workspace skeleton.
 - Tests exist and should be run from the workspace root with `pnpm test`.
 
@@ -84,7 +86,6 @@ Contains the versioned SQL source of truth for D1 schema changes.
 ## What Does Not Exist Yet
 
 - Additional deployable services
-- Verified authenticated Cloudflare operator access from this environment for remote D1 create, recreate, or migration work
 - Broader product/domain implementation
 - Authentication or authorization
 
@@ -97,13 +98,18 @@ Verified directly:
 - `pnpm test`
 - `pnpm -r run build`
 - `pnpm --filter @raid/web run cf:build`
-- `pnpm --filter @raid/web exec wrangler d1 migrations list raid-sl-clan --local` lists `0001_bootstrap.sql`
+- `pnpm --filter @raid/web exec wrangler d1 migrations apply raid-sl-clan --local`
+- `pnpm --filter @raid/web exec wrangler d1 migrations list raid-sl-clan --local` reports no unapplied migrations after local apply
+- `pnpm --filter @raid/web exec wrangler whoami` with token-based auth (`CLOUDFLARE_API_TOKEN`)
+- `pnpm --filter @raid/web exec wrangler d1 migrations list raid-sl-clan --remote` reports no unapplied migrations for production
+- `pnpm --filter @raid/web exec wrangler d1 execute raid-sl-clan --remote --command "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;"` lists the expected competition schema tables on production
+- `pnpm --filter @raid/web exec wrangler d1 migrations list raid-sl-clan --remote --preview` reports unapplied migrations for preview
 - `apps/web` has no nested `.git`
 
 Not yet verified:
 
 - Authenticated Cloudflare resource creation or recreation from this environment
-- Remote D1 migration execution from this environment
+- Remote preview D1 migration apply from this environment (preview is currently optional and not treated as a release gate)
 - Any production deployment path
 
 ## Architecture Rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ It reflects repository state as of 2026-04-26 and should be corrected when code 
 
 - Monorepo based on `pnpm` workspaces and TypeScript.
 - GitHub Actions is the source of truth for production build and deploy orchestration.
-- Cloudflare-first architecture with one active deployable in `apps/web`.
+- Cloudflare deployment with one active deployable in `apps/web`, while core architecture remains platform-neutral.
 - Runtime model: public website plus Telegram webhook served from the same Cloudflare deployment.
 - Internal package boundaries exist in `packages/core`, `packages/application`, `packages/ports`, and `packages/platform`.
 - Repository-owned D1 migrations live in `platform/migrations`.
@@ -24,7 +24,7 @@ It reflects repository state as of 2026-04-26 and should be corrected when code 
 - `pnpm-workspace.yaml`
   - Workspaces: `apps/*`, `packages/*`
 - `README.md`
-  - Cloudflare-first architecture, workflow, and validation guide
+  - Cloudflare deployment model, platform-neutral architecture rules, workflow, and validation guide
 - `tsconfig.base.json`
   - Shared TypeScript settings and path aliases
 - `vitest.config.ts`
@@ -74,7 +74,7 @@ Contains the versioned SQL source of truth for D1 schema changes.
 
 ## What Exists
 
-1. A Cloudflare-first monorepo with one active deployable surface in `apps/web`.
+1. A monorepo currently deployed on Cloudflare with one active deployable surface in `apps/web`.
 2. Shared package boundaries for domain, application, ports, and platform code.
 3. A root Vitest configuration with repository-level tests.
 4. A repository-owned D1 migration directory.
@@ -108,8 +108,9 @@ Not yet verified:
 
 ## Architecture Rules
 
-- Treat Cloudflare as the platform target unless the user explicitly changes direction.
+- Treat Cloudflare as the current runtime target while keeping architecture portable and migration-ready.
 - Keep Cloudflare-specific code in `apps/web` and `packages/platform`.
+- Keep domain and orchestration layers platform-neutral to avoid vendor lock-in.
 - Keep domain rules in `packages/core`.
 - Keep orchestration in `packages/application`.
 - Keep infrastructure contracts in `packages/ports`.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ pnpm --filter @raid/web exec wrangler d1 migrations apply raid-sl-clan --local
 pnpm --filter @raid/web exec wrangler d1 migrations list raid-sl-clan --local
 ```
 
-The local migrations list command has been verified to succeed and report `0001_bootstrap.sql`.
+The local migration apply and list commands have been verified with `0001_bootstrap.sql` and `0002_clan_competition_schema.sql`; after apply, local list reports no unapplied migrations.
+
+For remote validation (authenticated operator context), production D1 migration list has been verified to report no unapplied migrations.
+Preview D1 is currently optional and may intentionally remain behind production.
 
 Remote D1 creation, recreation, and remote migration work still require authenticated Cloudflare operator access. The repo contains committed binding IDs, but this repository does not pretend remote infrastructure can be changed without valid Cloudflare credentials.
 
@@ -95,7 +98,7 @@ pnpm deploy:web
 Before a manual deploy that depends on D1:
 
 1. authenticate Wrangler;
-2. confirm the target production and preview D1 databases match the committed binding, or update the binding if an authenticated operator has replaced them;
+2. confirm the target production D1 database matches the committed binding (and check preview only if your workflow depends on preview parity), or update the binding if an authenticated operator has replaced it;
 3. apply migrations remotely if the release depends on schema changes;
 4. deploy.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Raid SL Clan
 
-Cloudflare-first monorepo foundation for the Raid SL Clan website, Telegram webhook, and future D1-backed platform adapters.
+Cloudflare-deployed monorepo foundation for the Raid SL Clan website, Telegram webhook, and future D1-backed platform adapters, with platform-neutral core boundaries to avoid vendor lock-in.
 
 ## Architecture
 
-The active runtime target is Cloudflare, with one deployable application in `apps/web`.
+The current runtime deployment target is Cloudflare, with one deployable application in `apps/web`.
+Core and application layers are intentionally platform-neutral so the runtime can be migrated if needed.
 
 - `apps/web`: Next.js App Router application deployed through OpenNext on Cloudflare
 - `packages/core`: pure domain primitives and business rules
@@ -23,6 +24,7 @@ Current foundation scope:
 
 ## Repository Rules
 
+- Treat Cloudflare as the current deployment target, not a hard architectural dependency.
 - Keep Cloudflare runtime code in `apps/web` and `packages/platform`.
 - Keep `packages/core` free of Cloudflare SDKs, SQL, and transport concerns.
 - Keep `packages/application` focused on orchestration through `packages/ports`.

--- a/apps/web/public/images/clan-dashboard/background-desktop-dark-elves.png
+++ b/apps/web/public/images/clan-dashboard/background-desktop-dark-elves.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f77cfa49d5b70e6fd7f8d8b5976080a6606bacb6322fbebf2b302673c1846071
+size 2305799

--- a/apps/web/public/images/clan-dashboard/background-mobile-mavara.png
+++ b/apps/web/public/images/clan-dashboard/background-mobile-mavara.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5a5e0544de468fe6de731e458c2e201d2ac5f24bcaaef958bbdc1725d7dfaee
+size 2650639

--- a/docs/operator/cloudflare-bootstrap.md
+++ b/docs/operator/cloudflare-bootstrap.md
@@ -29,7 +29,7 @@ Cloudflare remains the runtime target, but Cloudflare dashboard repository build
 3. Create a temporary Hello World Worker to verify the account can issue a `*.workers.dev` URL.
 4. Run `pnpm --filter @raid/web exec wrangler login`.
 5. Confirm auth with `pnpm --filter @raid/web exec wrangler whoami`.
-6. Confirm the committed D1 binding in `apps/web/wrangler.jsonc` still matches the intended `raid-sl-clan` and `raid-sl-clan-preview` databases.
+6. Confirm the committed D1 binding in `apps/web/wrangler.jsonc` still matches the intended production database (`raid-sl-clan`) and, if used, the preview database (`raid-sl-clan-preview`).
 7. Create or replace those D1 databases only if an authenticated operator is intentionally changing remote infrastructure, then update `apps/web/wrangler.jsonc` with the returned IDs and keep `migrations_dir` set to `../../platform/migrations`.
 8. Create `.dev.vars` from `apps/web/.dev.vars.example`.
 9. Apply migrations locally with the committed binding, and apply them remotely only when authenticated Cloudflare access is available for the target database.
@@ -68,6 +68,7 @@ Token-based auth:
 
 ```bash
 export CLOUDFLARE_API_TOKEN=replace-me
+export CLOUDFLARE_ACCOUNT_ID=replace-me
 pnpm --filter @raid/web exec wrangler whoami
 ```
 
@@ -128,6 +129,7 @@ pnpm --filter @raid/web exec wrangler d1 migrations list raid-sl-clan --local
 ```
 
 The local migrations list command has already been verified to succeed and report `0001_bootstrap.sql`.
+After applying both committed migrations locally (`0001` and `0002`), local list should report no unapplied migrations.
 
 Create or replace the remote databases only after authentication succeeds and only when operator work actually requires new database IDs:
 
@@ -161,6 +163,12 @@ Apply migrations to the remote database only when authenticated Cloudflare acces
 
 ```bash
 pnpm --filter @raid/web exec wrangler d1 migrations apply raid-sl-clan --remote
+```
+
+If preview parity is required for your workflow, apply preview migrations explicitly:
+
+```bash
+pnpm --filter @raid/web exec wrangler d1 migrations apply raid-sl-clan --remote --preview
 ```
 
 ## Preview And Deploy
@@ -215,3 +223,5 @@ pnpm typecheck
 ```
 
 The local D1 command should use the committed binding and succeed. If remote D1 commands fail without Cloudflare authentication, that is expected; remote creation, replacement, and migration work remain operator-gated.
+Production remote migration list should return no unapplied migrations on a healthy release path.
+Preview migration status is optional unless your team explicitly treats preview parity as a gate.

--- a/docs/operator/cloudflare-bootstrap.md
+++ b/docs/operator/cloudflare-bootstrap.md
@@ -1,6 +1,6 @@
 # Cloudflare Bootstrap
 
-This repository deploys from `apps/web` as a Cloudflare-first Next.js + OpenNext application.
+This repository currently deploys from `apps/web` as a Next.js + OpenNext application on Cloudflare.
 There is one deployable surface in the current foundation:
 
 - the public web application;

--- a/docs/superpowers/plans/2026-04-26-raid-site-first-pages-implementation.md
+++ b/docs/superpowers/plans/2026-04-26-raid-site-first-pages-implementation.md
@@ -1,5 +1,7 @@
 # Raid SL Clan First Public Pages Implementation Plan
 
+Status: Completed and documented as implemented (validated on 2026-05-03)
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Replace the current one-page MVP shell in `apps/web` with four first-pass public pages backed by restored artwork, current App Router metadata assets, and a mobile-first public dashboard shell.
@@ -34,7 +36,7 @@
 - Create/restore: `apps/web/src/app/android-chrome-192x192.png`
 - Create/restore: `apps/web/src/app/android-chrome-512x512.png`
 
-- [ ] **Step 1: Write the failing test for the site content module**
+- [x] **Step 1: Write the failing test for the site content module**
 
 ```ts
 import { describe, expect, it } from "vitest";
@@ -74,13 +76,13 @@ describe("site content", () => {
 });
 ```
 
-- [ ] **Step 2: Run the test to verify it fails because the module does not exist yet**
+- [x] **Step 2: Run the test to verify it fails because the module does not exist yet**
 
 Run: `pnpm test -- apps/web/src/lib/site/content.test.ts`
 
 Expected: FAIL with a module resolution error for `./content`.
 
-- [ ] **Step 3: Write the minimal `content.ts` implementation**
+- [x] **Step 3: Write the minimal `content.ts` implementation**
 
 ```ts
 export const siteMetadataCopy = {
@@ -140,13 +142,13 @@ export const aboutPageSections = [
 ] as const;
 ```
 
-- [ ] **Step 4: Run the content test again and confirm green**
+- [x] **Step 4: Run the content test again and confirm green**
 
 Run: `pnpm test -- apps/web/src/lib/site/content.test.ts`
 
 Expected: PASS with 4 passing assertions.
 
-- [ ] **Step 5: Restore the historical artwork, font, and metadata source files from `b0067a8`**
+- [x] **Step 5: Restore the historical artwork, font, and metadata source files from `b0067a8`**
 
 Run:
 
@@ -176,7 +178,7 @@ git show b0067a8:apps/web/src/assets/meta/android-chrome-512x512.png > apps/web/
 
 Expected: restored binary assets exist at the new paths and `git status --short` shows them as new files on this branch.
 
-- [ ] **Step 6: Commit Task 1**
+- [x] **Step 6: Commit Task 1**
 
 ```bash
 git add \
@@ -203,7 +205,7 @@ git commit -m "feat: restore site artwork inputs"
 - Create: `apps/web/src/app/manifest.ts`
 - Test: `apps/web/src/app/layout.test.tsx`
 
-- [ ] **Step 1: Write the failing layout test**
+- [x] **Step 1: Write the failing layout test**
 
 ```tsx
 import React from "react";
@@ -234,13 +236,13 @@ describe("RootLayout", () => {
 });
 ```
 
-- [ ] **Step 2: Run the layout test to verify it fails on the current MVP layout**
+- [x] **Step 2: Run the layout test to verify it fails on the current MVP layout**
 
 Run: `pnpm test -- apps/web/src/app/layout.test.tsx`
 
 Expected: FAIL because the current `metadata.title` is a string and the rendered body does not include the `site-root` class.
 
-- [ ] **Step 3: Implement `layout.tsx` with local font wiring and richer metadata**
+- [x] **Step 3: Implement `layout.tsx` with local font wiring and richer metadata**
 
 ```tsx
 import type { Metadata } from "next";
@@ -292,7 +294,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
 }
 ```
 
-- [ ] **Step 4: Add the App Router manifest route using the restored icon assets**
+- [x] **Step 4: Add the App Router manifest route using the restored icon assets**
 
 ```ts
 import type { MetadataRoute } from "next";
@@ -320,7 +322,7 @@ export default function manifest(): MetadataRoute.Manifest {
 }
 ```
 
-- [ ] **Step 5: Replace `globals.css` with the shared tokens and layout primitives the new pages need**
+- [x] **Step 5: Replace `globals.css` with the shared tokens and layout primitives the new pages need**
 
 ```css
 @import "tailwindcss";
@@ -537,13 +539,13 @@ img {
 }
 ```
 
-- [ ] **Step 6: Run the layout test again**
+- [x] **Step 6: Run the layout test again**
 
 Run: `pnpm test -- apps/web/src/app/layout.test.tsx`
 
 Expected: PASS with metadata and `site-root` assertions satisfied.
 
-- [ ] **Step 7: Commit Task 2**
+- [x] **Step 7: Commit Task 2**
 
 ```bash
 git add \
@@ -563,7 +565,7 @@ git commit -m "feat: rebuild public site shell metadata"
 - Modify: `apps/web/src/app/page.tsx`
 - Modify: `apps/web/src/app/page.test.tsx`
 
-- [ ] **Step 1: Replace the old landing test with one that describes the new root route**
+- [x] **Step 1: Replace the old landing test with one that describes the new root route**
 
 ```tsx
 import React from "react";
@@ -585,13 +587,13 @@ describe("HomePage", () => {
 });
 ```
 
-- [ ] **Step 2: Run the landing test and verify it fails on the old MVP shell**
+- [x] **Step 2: Run the landing test and verify it fails on the old MVP shell**
 
 Run: `pnpm test -- apps/web/src/app/page.test.tsx`
 
 Expected: FAIL because the current landing page still renders the Cloudflare MVP copy and has no `About` link or login placeholder.
 
-- [ ] **Step 3: Create the shared atmospheric primitives**
+- [x] **Step 3: Create the shared atmospheric primitives**
 
 `apps/web/src/components/site/brand-mark.tsx`
 
@@ -656,7 +658,7 @@ export function PageBackdrop({ imagePath, children }: PageBackdropProps) {
 }
 ```
 
-- [ ] **Step 4: Implement the new landing page**
+- [x] **Step 4: Implement the new landing page**
 
 ```tsx
 import { AtmosphericLink } from "../components/site/atmospheric-link";
@@ -705,13 +707,13 @@ export default function HomePage() {
 }
 ```
 
-- [ ] **Step 5: Run the landing test again**
+- [x] **Step 5: Run the landing test again**
 
 Run: `pnpm test -- apps/web/src/app/page.test.tsx`
 
 Expected: PASS with the new landing copy and links present.
 
-- [ ] **Step 6: Commit Task 3**
+- [x] **Step 6: Commit Task 3**
 
 ```bash
 git add \
@@ -731,7 +733,7 @@ git commit -m "feat: add atmospheric landing route"
 - Create: `apps/web/src/app/not-found.tsx`
 - Create: `apps/web/src/app/not-found.test.tsx`
 
-- [ ] **Step 1: Write the failing tests for `About` and `404`**
+- [x] **Step 1: Write the failing tests for `About` and `404`**
 
 `apps/web/src/app/about/page.test.tsx`
 
@@ -772,13 +774,13 @@ describe("NotFoundPage", () => {
 });
 ```
 
-- [ ] **Step 2: Run the tests and confirm they fail because the routes do not exist yet**
+- [x] **Step 2: Run the tests and confirm they fail because the routes do not exist yet**
 
 Run: `pnpm test -- apps/web/src/app/about/page.test.tsx apps/web/src/app/not-found.test.tsx`
 
 Expected: FAIL with module resolution errors for both route files.
 
-- [ ] **Step 3: Implement the editorial `About` page**
+- [x] **Step 3: Implement the editorial `About` page**
 
 ```tsx
 import { AtmosphericLink } from "../../components/site/atmospheric-link";
@@ -816,7 +818,7 @@ export default function AboutPage() {
 }
 ```
 
-- [ ] **Step 4: Implement the custom `not-found.tsx` route**
+- [x] **Step 4: Implement the custom `not-found.tsx` route**
 
 ```tsx
 import { AtmosphericLink } from "../components/site/atmospheric-link";
@@ -840,13 +842,13 @@ export default function NotFoundPage() {
 }
 ```
 
-- [ ] **Step 5: Run the route tests again**
+- [x] **Step 5: Run the route tests again**
 
 Run: `pnpm test -- apps/web/src/app/about/page.test.tsx apps/web/src/app/not-found.test.tsx`
 
 Expected: PASS with both new atmospheric pages rendering.
 
-- [ ] **Step 6: Commit Task 4**
+- [x] **Step 6: Commit Task 4**
 
 ```bash
 git add \
@@ -865,7 +867,7 @@ git commit -m "feat: add editorial public routes"
 - Create: `apps/web/src/app/dashboard/page.tsx`
 - Create: `apps/web/src/app/dashboard/page.test.tsx`
 
-- [ ] **Step 1: Write the failing dashboard test**
+- [x] **Step 1: Write the failing dashboard test**
 
 ```tsx
 import React from "react";
@@ -889,13 +891,13 @@ describe("DashboardPage", () => {
 });
 ```
 
-- [ ] **Step 2: Run the dashboard test and verify it fails because the route does not exist**
+- [x] **Step 2: Run the dashboard test and verify it fails because the route does not exist**
 
 Run: `pnpm test -- apps/web/src/app/dashboard/page.test.tsx`
 
 Expected: FAIL with a module resolution error for `./page`.
 
-- [ ] **Step 3: Create the dashboard shell primitives**
+- [x] **Step 3: Create the dashboard shell primitives**
 
 `apps/web/src/components/site/panel-card.tsx`
 
@@ -935,7 +937,7 @@ export function DashboardNav() {
 }
 ```
 
-- [ ] **Step 4: Implement the public dashboard route**
+- [x] **Step 4: Implement the public dashboard route**
 
 ```tsx
 import { BrandMark } from "../../components/site/brand-mark";
@@ -967,13 +969,13 @@ export default function DashboardPage() {
 }
 ```
 
-- [ ] **Step 5: Run the dashboard test again**
+- [x] **Step 5: Run the dashboard test again**
 
 Run: `pnpm test -- apps/web/src/app/dashboard/page.test.tsx`
 
 Expected: PASS with the shell title, menu summary, and four section titles present.
 
-- [ ] **Step 6: Commit Task 5**
+- [x] **Step 6: Commit Task 5**
 
 ```bash
 git add \
@@ -989,25 +991,25 @@ git commit -m "feat: add public dashboard route"
 **Files:**
 - Modify only if verification uncovers defects
 
-- [ ] **Step 1: Run the targeted web app tests together**
+- [x] **Step 1: Run the targeted web app tests together**
 
 Run: `pnpm test -- apps/web/src/app/layout.test.tsx apps/web/src/app/page.test.tsx apps/web/src/app/about/page.test.tsx apps/web/src/app/not-found.test.tsx apps/web/src/app/dashboard/page.test.tsx apps/web/src/lib/site/content.test.ts`
 
 Expected: PASS for all new route and content tests.
 
-- [ ] **Step 2: Run the full repository test suite**
+- [x] **Step 2: Run the full repository test suite**
 
 Run: `pnpm test`
 
 Expected: PASS across the repo.
 
-- [ ] **Step 3: Run the workspace typecheck**
+- [x] **Step 3: Run the workspace typecheck**
 
 Run: `pnpm typecheck`
 
 Expected: PASS across `apps/*` and `packages/*`.
 
-- [ ] **Step 4: Start the local web app and review the routes in the browser**
+- [x] **Step 4: Start the local web app and review the routes in the browser**
 
 Run:
 
@@ -1034,10 +1036,9 @@ Expected:
 - `About` reads like an editorial page instead of a dashboard clone
 - `404` stays readable on top of the restored dark artwork
 
-- [ ] **Step 5: Commit the final polish or verification-driven fixes**
+- [x] **Step 5: Commit the final polish or verification-driven fixes**
 
 ```bash
 git add apps/web
 git commit -m "feat: finalize first public website pages"
 ```
-

--- a/docs/superpowers/plans/2026-04-27-clan-competition-schema-migration-implementation.md
+++ b/docs/superpowers/plans/2026-04-27-clan-competition-schema-migration-implementation.md
@@ -1,5 +1,7 @@
 # Clan Competition Schema Migration Implementation Plan
 
+Status: Completed for local and production schema state (validated on 2026-05-03); preview migration parity is optional and currently not enforced
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add the first D1 migration for clan competition tracking, covering shared competition windows, player identity, mode-specific reports, team-level Hydra/Chimera detail, and summary roster observations.
@@ -16,7 +18,7 @@
 - Create: `packages/platform/test/clan-competition-schema.test.ts`
 - Test: `packages/platform/test/clan-competition-schema.test.ts`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```ts
 import { readFileSync } from "node:fs";
@@ -66,13 +68,13 @@ describe("clan competition schema migration", () => {
 });
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `pnpm test -- packages/platform/test/clan-competition-schema.test.ts`
 
 Expected: FAIL because `0002_clan_competition_schema.sql` and the new tables do not exist yet.
 
-- [ ] **Step 3: Extend the test with the most important constraints**
+- [x] **Step 3: Extend the test with the most important constraints**
 
 ```ts
 it("stores champion roster observations as a summary table with a unique player/champion key", () => {
@@ -100,13 +102,13 @@ it("constrains Hydra and Chimera data completeness fields", () => {
 });
 ```
 
-- [ ] **Step 4: Run test to verify it still fails for the right reason**
+- [x] **Step 4: Run test to verify it still fails for the right reason**
 
 Run: `pnpm test -- packages/platform/test/clan-competition-schema.test.ts`
 
 Expected: FAIL because the migration still has not been implemented, not because the test file is malformed.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add packages/platform/test/clan-competition-schema.test.ts
@@ -119,7 +121,7 @@ git commit -m "test: add clan competition schema contract tests"
 - Create: `platform/migrations/0002_clan_competition_schema.sql`
 - Modify: `packages/platform/test/clan-competition-schema.test.ts`
 
-- [ ] **Step 1: Write the migration SQL**
+- [x] **Step 1: Write the migration SQL**
 
 ```sql
 CREATE TABLE IF NOT EXISTS competition_window (
@@ -154,7 +156,7 @@ CREATE TABLE IF NOT EXISTS siege_report (...);
 CREATE TABLE IF NOT EXISTS champion_roster_observation (...);
 ```
 
-- [ ] **Step 2: Include the critical constraints**
+- [x] **Step 2: Include the critical constraints**
 
 ```sql
 CHECK (data_completeness IN ('aggregate_only', 'partial_detail', 'full_detail'))
@@ -169,13 +171,13 @@ UNIQUE (chimera_team_run_id, slot_index)
 UNIQUE (player_profile_id, champion_code)
 ```
 
-- [ ] **Step 3: Run the schema contract test**
+- [x] **Step 3: Run the schema contract test**
 
 Run: `pnpm test -- packages/platform/test/clan-competition-schema.test.ts`
 
 Expected: PASS
 
-- [ ] **Step 4: Refine the test if the SQL needs one more assertion**
+- [x] **Step 4: Refine the test if the SQL needs one more assertion**
 
 ```ts
 it("stores Hydra keys as keys_used", () => {
@@ -186,7 +188,7 @@ it("stores Hydra keys as keys_used", () => {
 });
 ```
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add platform/migrations/0002_clan_competition_schema.sql packages/platform/test/clan-competition-schema.test.ts
@@ -198,31 +200,31 @@ git commit -m "feat: add clan competition schema migration"
 **Files:**
 - Modify: none unless verification reveals a real schema bug
 
-- [ ] **Step 1: Run the focused tests**
+- [x] **Step 1: Run the focused tests**
 
 Run: `pnpm test -- packages/platform/test/clan-competition-schema.test.ts`
 
 Expected: PASS
 
-- [ ] **Step 2: Run the full test suite**
+- [x] **Step 2: Run the full test suite**
 
 Run: `pnpm test`
 
 Expected: PASS with the existing suite still green.
 
-- [ ] **Step 3: Apply local D1 migrations**
+- [x] **Step 3: Apply local D1 migrations**
 
 Run: `pnpm --filter @raid/web exec wrangler d1 migrations apply raid-sl-clan --local`
 
 Expected: SUCCESS with `0001_bootstrap.sql` and `0002_clan_competition_schema.sql` applied locally.
 
-- [ ] **Step 4: List local migrations**
+- [x] **Step 4: List local migrations**
 
 Run: `pnpm --filter @raid/web exec wrangler d1 migrations list raid-sl-clan --local`
 
 Expected: both migrations listed as applied locally.
 
-- [ ] **Step 5: Commit verification-only fixes if needed**
+- [x] **Step 5: Commit verification-only fixes if needed**
 
 ```bash
 git add <any adjusted files>

--- a/docs/superpowers/specs/2026-04-26-cloudflare-mvp-foundation-design.md
+++ b/docs/superpowers/specs/2026-04-26-cloudflare-mvp-foundation-design.md
@@ -4,7 +4,7 @@
 
 ## Goal
 
-Replace the current legacy scaffold with a Cloudflare-first monorepo foundation that can ship:
+Replace the current legacy scaffold with a monorepo foundation deployed on Cloudflare that can ship:
 
 - a publicly reachable website;
 - a minimal Telegram webhook bot;
@@ -17,7 +17,7 @@ This is a foundation spec for the first sub-project only. It does not attempt to
 ### In scope
 
 - remove the current legacy delivery/infrastructure scaffold from the active path;
-- establish a Cloudflare-first monorepo structure;
+- establish a Cloudflare-deployed monorepo structure with platform-neutral core boundaries;
 - create one `Next.js + OpenNext` deployable for both site delivery and Telegram webhook handling;
 - define architectural boundaries for `core`, `application`, `ports`, `platform`, and `apps/web`;
 - initialize `beads` in this repository with GitHub integration;
@@ -350,7 +350,7 @@ The following legacy scaffold is intentionally removed from the repository:
 - `services/mcp`;
 - `infra/compose`.
 
-These pieces represent a previous direction that conflicts with the Cloudflare-first MVP foundation and should not remain as semi-supported baggage.
+These pieces represent a previous direction that conflicts with the current Cloudflare-deployed MVP foundation and should not remain as semi-supported baggage.
 
 ## Error Handling
 

--- a/docs/superpowers/specs/2026-04-26-raid-site-first-pages-design.md
+++ b/docs/superpowers/specs/2026-04-26-raid-site-first-pages-design.md
@@ -6,7 +6,7 @@ Related issue: `raid-sl-clan-8gx`
 
 ## 1. Context
 
-The repository already contains the current Cloudflare-first Next.js application in `apps/web`, but the public site surface is still a single MVP shell. Historical artwork existed before the cleanup in commit `b0067a8`:
+The repository already contains the current Next.js application in `apps/web` deployed on Cloudflare, but the public site surface is still a single MVP shell. Historical artwork existed before the cleanup in commit `b0067a8`:
 
 - `apps/web/src/assets/landing/*`
 - `apps/web/src/assets/404/*`

--- a/docs/superpowers/specs/2026-05-03-clan-dashboard-mobile-first-design.md
+++ b/docs/superpowers/specs/2026-05-03-clan-dashboard-mobile-first-design.md
@@ -47,8 +47,8 @@ Additional goals:
 
 Atmospheric dark background with translucent cards:
 
-- Desktop background source: `~/Downloads/dark-elves.png` (16:9).
-- Mobile background source: `~/Downloads/mavara.png` (portrait).
+- Desktop background source: `apps/web/public/images/clan-dashboard/background-desktop-dark-elves.png` (16:9 hero/background image for desktop layouts).
+- Mobile background source: `apps/web/public/images/clan-dashboard/background-mobile-mavara.png` (portrait background image optimized for mobile layouts).
 - Content overlays on semi-transparent panels for readability.
 
 Navigation:

--- a/docs/superpowers/specs/2026-05-03-clan-dashboard-mobile-first-design.md
+++ b/docs/superpowers/specs/2026-05-03-clan-dashboard-mobile-first-design.md
@@ -1,0 +1,242 @@
+# Raid SL Clan Mobile-First Clan Dashboard Design
+
+Date: 2026-05-03  
+Status: Draft for review
+
+## 1. Context
+
+The current site foundation is in place, but the public dashboard must become a practical clan page for everyday members, not just an MVP shell.  
+Historical imports already provide useful competition data in D1 for Hydra, Chimera, Clan Wars (KT), and Siege at the report level.  
+The dashboard should prioritize immediate usefulness on mobile while still presenting a strong atmospheric desktop layout.
+
+## 2. Primary User
+
+Primary user: all clan members (mobile-first).
+
+This dashboard should answer "what matters right now?" in seconds:
+
+- current readiness by activity;
+- current important event (fusion);
+- current top/bottom performers by activity;
+- short-term trends.
+
+## 3. Goals
+
+Deliver one mobile-first dashboard page with four zones:
+
+1. `Зона боеготовности`
+2. `Зона слияния`
+3. `Зона топ перформеров`
+4. `Зона тренды`
+
+Additional goals:
+
+- Preserve one interaction pattern for activity switching (`chips + swipe`) where applicable.
+- Keep ranking logic intentionally simple (rank all active players, including zeroes).
+- Use D1 as primary source where schema already supports the metric.
+- Keep fusion as a repository-managed temporary source.
+
+## 4. Non-Goals
+
+- Building full per-activity analytics pages in this scope.
+- Building an admin UI for fusion/event editing.
+- Building a complete fusion calendar parser (calendar stays an image for v1).
+- Treating preview D1 parity as a release gate.
+
+## 5. Visual Direction
+
+Atmospheric dark background with translucent cards:
+
+- Desktop background source: `~/Downloads/dark-elves.png` (16:9).
+- Mobile background source: `~/Downloads/mavara.png` (portrait).
+- Content overlays on semi-transparent panels for readability.
+
+Navigation:
+
+- Mobile: hamburger menu.
+- Desktop: visible menu items.
+
+## 6. Information Architecture
+
+### 6.1 `Зона боеготовности`
+
+Four clickable cards:
+
+- Hydra
+- Chimera
+- KT (Clan Wars)
+- Siege
+
+Card intent:
+
+- Hydra/Chimera: keys spent, total current damage, countdown to reset.
+- KT: countdown to start, status (`с личными наградами` / `без`).
+- Siege: countdown to start.
+
+Cards are links to future detailed pages for each activity.
+
+### 6.2 `Зона слияния`
+
+Single "current important event" block.
+
+v1 source: manual JSON in repository (temporary solution).
+
+States:
+
+- Active fusion: hero name + portrait + period + calendar image link.
+- No fusion: explicit idle state (`Слияния сейчас нет`).
+
+### 6.3 `Зона топ перформеров`
+
+Two independent blocks:
+
+- `Top 5 Performers`
+- `Bottom 5`
+
+Each block has its own activity selector:
+
+- `Hydra / Chimera / KT / Siege(def)`
+- pattern: chips + swipe
+- default: `Hydra`
+
+Population rule (both blocks): only current clan roster (`player_profile.status = 'active'`).
+
+Ranking rule: include all active players (including zero values), no minimum participation thresholds.
+
+Activity metrics:
+
+- Hydra: sum damage (current selected reporting range).
+- Chimera: sum damage.
+- KT: sum points over the latest 4 KT reports with personal rewards.
+- Siege(def): defense wins.
+
+KT note below table:
+
+`* KT ranking is calculated as SUM(points) over the latest 4 KT reports with personal rewards.`
+
+### 6.4 `Зона тренды`
+
+8-week trend block for Hydra and Chimera (2 months).
+
+Scope for v1:
+
+- clan-level aggregate trend, not per-player deep analytics.
+- mobile readable chart/card treatment.
+
+## 7. Time And Date Rules
+
+Canonical rule:
+
+- All stored timestamps in DB/JSON are ISO8601 strings with offset (typically UTC).
+
+Display rule:
+
+- Convert for user display via `Intl` in user timezone (`Intl.DateTimeFormat().resolvedOptions().timeZone`).
+- No manual timezone math.
+
+## 8. Countdown Component Contract
+
+Introduce one shared countdown component for all relevant zones.
+
+Behavior:
+
+- Input: target ISO datetime.
+- Output formatting:
+  - default: days + hours
+  - under 1 hour: minutes + seconds
+- Adaptive tick cadence (do not rerender every second when unnecessary).
+- Emit one-shot `onTimerEnd` when crossing zero.
+- Stop internal interval after end event.
+
+Container-level end messages:
+
+- Fusion: `Слияние закончено`
+- Hydra/Chimera/KT/Siege: `Закончено, идет подсчет результатов`
+
+The post-end state remains until next data refresh/import.
+
+## 9. Data Sources And Schema Implications
+
+### 9.1 Data already covered by D1
+
+- Readiness windows: `competition_window` + mode reports.
+- Hydra/Chimera aggregates: `*_player_result`.
+- KT points: `clan_wars_player_score`.
+- Active roster filter: `player_profile.status`.
+- Trends: competition windows + mode aggregates.
+
+### 9.2 Fusion data (temporary)
+
+Repository JSON model for v1:
+
+- `status`: `active | idle`
+- `title`
+- `startsAt` (ISO)
+- `endsAt` (ISO)
+- `heroPortraitImageUrl` (required)
+- `calendarImageUrl` (required for active)
+- `note` (optional)
+
+### 9.3 Required schema update for KT rewards flag
+
+Current schema does not include a personal-rewards flag for KT reports.
+
+Required migration:
+
+- add `has_personal_rewards INTEGER NOT NULL DEFAULT 0 CHECK (has_personal_rewards IN (0,1))`
+  to `clan_wars_report`.
+
+KT ranking query logic:
+
+- take latest 4 reports where `has_personal_rewards = 1` (by `created_at DESC`);
+- aggregate `SUM(points)` from `clan_wars_player_score`;
+- if fewer than 4 reports exist, use available rows.
+
+### 9.4 Siege(def) metric data gap
+
+Current schema stores siege report outcome at match level, but does not yet store per-player defense wins.
+
+Therefore, `Siege(def)` ranking requires one of:
+
+1. schema extension for per-player siege stats (recommended), or
+2. temporary manual import source for defense wins.
+
+Recommendation: add a dedicated per-player siege stats table in a follow-up migration and feed it through imports.
+
+## 10. Mobile Interaction Pattern
+
+For activity switching in ranking blocks:
+
+- explicit chips (discoverable for tap users),
+- optional swipe (faster for gesture users),
+- same pattern reused in both `Top 5` and `Bottom 5`.
+
+No nested tabs inside tabs.
+
+## 11. Error Handling And Empty States
+
+- Missing/late data in a zone should render a clear placeholder, not break page layout.
+- Countdown with invalid/missing target datetime should render a neutral fallback (`—`) and log a typed warning.
+- Fusion idle state is first-class, not an error.
+
+## 12. Testing Expectations
+
+Minimum verification for this design:
+
+- Unit tests for countdown formatting and `onTimerEnd` one-shot behavior.
+- Unit tests for timezone-aware date rendering component.
+- Query tests for KT latest-4-with-personal-rewards aggregation.
+- Query tests for active-roster filtering in Top/Bottom lists.
+- Rendering tests for zone presence and activity selector defaults (`Hydra`).
+
+## 13. Implementation Recommendation
+
+Recommended order:
+
+1. Add `has_personal_rewards` migration for KT.
+2. Implement shared date/countdown primitives.
+3. Implement zones with D1-backed data fetchers.
+4. Add fusion JSON source and rendering.
+5. Add temporary Siege(def) handling with explicit TODO for full D1 support.
+
+This order keeps the dashboard immediately useful while exposing data gaps explicitly instead of hiding them.


### PR DESCRIPTION
## Summary
- sync AGENTS/README/operator docs with current verified repository state
- mark both implementation plans as completed and add explicit status lines
- add new design spec for the mobile-first clan dashboard zones

## Notes
- preview D1 parity is documented as optional (not a release gate)
- spec includes required KT schema extension (has_personal_rewards) and current Siege(def) data gap