### PR TITLE
Dashboard tuning + local D1 sync scaffold

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "preview": "pnpm run cf:build && opennextjs-cloudflare preview",
     "deploy": "pnpm run cf:build && opennextjs-cloudflare deploy",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts",
+    "d1:sync:prod-to-local": "bash ./scripts/sync-d1-prod-to-local.sh",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint"
   },

--- a/apps/web/scripts/sync-d1-prod-to-local.sh
+++ b/apps/web/scripts/sync-d1-prod-to-local.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${CLOUDFLARE_API_TOKEN:-}" ]]; then
+  echo "CLOUDFLARE_API_TOKEN is not set. Export it before running this sync." >&2
+  exit 1
+fi
+
+DB_NAME="${1:-raid-sl-clan}"
+PERSIST_DIR="${2:-.wrangler/state/prod-snapshot}"
+SNAPSHOT_DIR="${3:-.wrangler/d1-sync}"
+
+case "$PERSIST_DIR" in
+  .wrangler/*) ;;
+  *)
+    echo "Refusing to reset persist dir outside .wrangler/: $PERSIST_DIR" >&2
+    exit 1
+    ;;
+esac
+
+mkdir -p "$SNAPSHOT_DIR"
+SNAPSHOT_PATH="$SNAPSHOT_DIR/prod-$(date +%Y%m%d-%H%M%S).sql"
+
+echo "Exporting remote D1 database '$DB_NAME' to $SNAPSHOT_PATH"
+pnpm exec wrangler d1 export "$DB_NAME" --remote --output "$SNAPSHOT_PATH" --skip-confirmation
+
+echo "Resetting local persist dir $PERSIST_DIR"
+rm -rf "$PERSIST_DIR"
+mkdir -p "$PERSIST_DIR"
+
+echo "Importing snapshot into local D1 ($PERSIST_DIR)"
+pnpm exec wrangler d1 execute "$DB_NAME" --local --persist-to "$PERSIST_DIR" --file "$SNAPSHOT_PATH" --yes
+
+echo "Verifying imported tables"
+pnpm exec wrangler d1 execute "$DB_NAME" --local --persist-to "$PERSIST_DIR" --command "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;"
+
+echo "Sync complete."
+echo "Snapshot: $SNAPSHOT_PATH"
+echo "Persist:  $PERSIST_DIR"

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -221,6 +221,12 @@ img {
   gap: 0.6rem;
 }
 
+.dashboard-performers-columns,
+.dashboard-trends-columns {
+  display: grid;
+  gap: 1rem;
+}
+
 .dashboard-activity-chips {
   display: flex;
   gap: 0.5rem;
@@ -359,6 +365,14 @@ p {
     background-image:
       linear-gradient(180deg, rgba(6, 8, 11, 0.74), rgba(6, 8, 11, 0.9)),
       url("/images/clan-dashboard/background-desktop-dark-elves.png");
+  }
+}
+
+@media (min-width: 1200px) {
+  .dashboard-performers-columns,
+  .dashboard-trends-columns {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
   }
 }
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -3,7 +3,7 @@
 :root {
   color-scheme: dark;
   --site-bg: #07090d;
-  --site-panel: rgba(9, 12, 16, 0.78);
+  --site-panel: #090c1040;
   --site-panel-strong: rgba(6, 8, 11, 0.88);
   --site-border: rgba(196, 210, 223, 0.14);
   --site-text: #f3f4f6;
@@ -116,7 +116,6 @@ img {
   border-radius: 1.25rem;
   background: var(--site-panel);
   box-shadow: 0 1.5rem 3rem -2rem var(--site-shadow);
-  backdrop-filter: blur(14px);
 }
 
 .panel-card--padded {
@@ -203,7 +202,7 @@ img {
   border: 1px solid var(--site-border);
   border-radius: 1rem;
   padding: 0.9rem;
-  background: rgba(6, 8, 11, 0.58);
+  background: var(--site-panel);
 }
 
 .dashboard-fusion-active {

--- a/apps/web/src/components/site/dashboard-performers-zone.tsx
+++ b/apps/web/src/components/site/dashboard-performers-zone.tsx
@@ -2,6 +2,7 @@
 
 import React, { useRef, useState } from "react";
 import type { DashboardActivity, DashboardTopBottom } from "@raid/ports";
+import { LocalizedNumber } from "./localized-number";
 
 const activities: DashboardActivity[] = [
   "hydra",
@@ -96,7 +97,14 @@ export function DashboardPerformersZone({ rankings }: DashboardPerformersZonePro
             {rankings[topActivity].top5.map((row) => (
               <li key={`top-${topActivity}-${row.playerName}`}>
                 <span>{row.playerName}</span>
-                <strong>{row.score.toLocaleString("en-US")}</strong>
+                <strong>
+                  <LocalizedNumber
+                    value={row.score}
+                    notation="compact"
+                    compactDisplay="short"
+                    maximumFractionDigits={1}
+                  />
+                </strong>
               </li>
             ))}
           </ol>
@@ -138,7 +146,14 @@ export function DashboardPerformersZone({ rankings }: DashboardPerformersZonePro
             {rankings[bottomActivity].bottom5.map((row) => (
               <li key={`bottom-${bottomActivity}-${row.playerName}`}>
                 <span>{row.playerName}</span>
-                <strong>{row.score.toLocaleString("en-US")}</strong>
+                <strong>
+                  <LocalizedNumber
+                    value={row.score}
+                    notation="compact"
+                    compactDisplay="short"
+                    maximumFractionDigits={1}
+                  />
+                </strong>
               </li>
             ))}
           </ol>

--- a/apps/web/src/components/site/dashboard-performers-zone.tsx
+++ b/apps/web/src/components/site/dashboard-performers-zone.tsx
@@ -59,106 +59,108 @@ export function DashboardPerformersZone({ rankings }: DashboardPerformersZonePro
   const showKtNote = topActivity === "clan_wars" || bottomActivity === "clan_wars";
 
   return (
-    <section className="panel-card panel-card--padded dashboard-stack">
+    <section className="panel-card panel-card--padded dashboard-stack dashboard-performers-zone">
       <h2 className="display-face">Зона топ перформеров</h2>
 
-      <article className="dashboard-performers-block">
-        <h3>Top 5 Performers</h3>
-        <div className="dashboard-activity-chips" role="tablist" aria-label="Top performers activity selector">
-          {activities.map((activity) => (
-            <button
-              key={`top-${activity}`}
-              type="button"
-              className="dashboard-chip"
-              aria-pressed={topActivity === activity}
-              onClick={() => setTopActivity(activity)}
-            >
-              {activityLabels[activity]}
-            </button>
-          ))}
-        </div>
-
-        <div
-          className="dashboard-swipe-surface"
-          onTouchStart={(event) => {
-            topTouchStartX.current = event.touches[0]?.clientX ?? null;
-          }}
-          onTouchEnd={(event) => {
-            handleSwipe(
-              topTouchStartX.current,
-              event.changedTouches[0]?.clientX ?? 0,
-              topActivity,
-              setTopActivity
-            );
-            topTouchStartX.current = null;
-          }}
-        >
-          <ol className="dashboard-ranking-list">
-            {rankings[topActivity].top5.map((row) => (
-              <li key={`top-${topActivity}-${row.playerName}`}>
-                <span>{row.playerName}</span>
-                <strong>
-                  <LocalizedNumber
-                    value={row.score}
-                    notation="compact"
-                    compactDisplay="short"
-                    maximumFractionDigits={1}
-                  />
-                </strong>
-              </li>
+      <div className="dashboard-performers-columns">
+        <article className="dashboard-performers-block">
+          <h3>Top 5 Performers</h3>
+          <div className="dashboard-activity-chips" role="tablist" aria-label="Top performers activity selector">
+            {activities.map((activity) => (
+              <button
+                key={`top-${activity}`}
+                type="button"
+                className="dashboard-chip"
+                aria-pressed={topActivity === activity}
+                onClick={() => setTopActivity(activity)}
+              >
+                {activityLabels[activity]}
+              </button>
             ))}
-          </ol>
-        </div>
-      </article>
+          </div>
 
-      <article className="dashboard-performers-block">
-        <h3>Bottom 5</h3>
-        <div className="dashboard-activity-chips" role="tablist" aria-label="Bottom performers activity selector">
-          {activities.map((activity) => (
-            <button
-              key={`bottom-${activity}`}
-              type="button"
-              className="dashboard-chip"
-              aria-pressed={bottomActivity === activity}
-              onClick={() => setBottomActivity(activity)}
-            >
-              {activityLabels[activity]}
-            </button>
-          ))}
-        </div>
+          <div
+            className="dashboard-swipe-surface"
+            onTouchStart={(event) => {
+              topTouchStartX.current = event.touches[0]?.clientX ?? null;
+            }}
+            onTouchEnd={(event) => {
+              handleSwipe(
+                topTouchStartX.current,
+                event.changedTouches[0]?.clientX ?? 0,
+                topActivity,
+                setTopActivity
+              );
+              topTouchStartX.current = null;
+            }}
+          >
+            <ol className="dashboard-ranking-list">
+              {rankings[topActivity].top5.map((row) => (
+                <li key={`top-${topActivity}-${row.playerName}`}>
+                  <span>{row.playerName}</span>
+                  <strong>
+                    <LocalizedNumber
+                      value={row.score}
+                      notation="compact"
+                      compactDisplay="short"
+                      maximumFractionDigits={1}
+                    />
+                  </strong>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </article>
 
-        <div
-          className="dashboard-swipe-surface"
-          onTouchStart={(event) => {
-            bottomTouchStartX.current = event.touches[0]?.clientX ?? null;
-          }}
-          onTouchEnd={(event) => {
-            handleSwipe(
-              bottomTouchStartX.current,
-              event.changedTouches[0]?.clientX ?? 0,
-              bottomActivity,
-              setBottomActivity
-            );
-            bottomTouchStartX.current = null;
-          }}
-        >
-          <ol className="dashboard-ranking-list">
-            {rankings[bottomActivity].bottom5.map((row) => (
-              <li key={`bottom-${bottomActivity}-${row.playerName}`}>
-                <span>{row.playerName}</span>
-                <strong>
-                  <LocalizedNumber
-                    value={row.score}
-                    notation="compact"
-                    compactDisplay="short"
-                    maximumFractionDigits={1}
-                  />
-                </strong>
-              </li>
+        <article className="dashboard-performers-block">
+          <h3>Bottom 5</h3>
+          <div className="dashboard-activity-chips" role="tablist" aria-label="Bottom performers activity selector">
+            {activities.map((activity) => (
+              <button
+                key={`bottom-${activity}`}
+                type="button"
+                className="dashboard-chip"
+                aria-pressed={bottomActivity === activity}
+                onClick={() => setBottomActivity(activity)}
+              >
+                {activityLabels[activity]}
+              </button>
             ))}
-          </ol>
-        </div>
-      </article>
+          </div>
+
+          <div
+            className="dashboard-swipe-surface"
+            onTouchStart={(event) => {
+              bottomTouchStartX.current = event.touches[0]?.clientX ?? null;
+            }}
+            onTouchEnd={(event) => {
+              handleSwipe(
+                bottomTouchStartX.current,
+                event.changedTouches[0]?.clientX ?? 0,
+                bottomActivity,
+                setBottomActivity
+              );
+              bottomTouchStartX.current = null;
+            }}
+          >
+            <ol className="dashboard-ranking-list">
+              {rankings[bottomActivity].bottom5.map((row) => (
+                <li key={`bottom-${bottomActivity}-${row.playerName}`}>
+                  <span>{row.playerName}</span>
+                  <strong>
+                    <LocalizedNumber
+                      value={row.score}
+                      notation="compact"
+                      compactDisplay="short"
+                      maximumFractionDigits={1}
+                    />
+                  </strong>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </article>
+      </div>
 
       {showKtNote ? (
         <p className="dashboard-note">

--- a/apps/web/src/components/site/dashboard-readiness-zone.tsx
+++ b/apps/web/src/components/site/dashboard-readiness-zone.tsx
@@ -2,12 +2,18 @@ import React from "react";
 import Link from "next/link";
 import type { DashboardReadinessCard } from "@raid/ports";
 import { CountdownTimer } from "./countdown-timer";
+import { LocalizedNumber } from "./localized-number";
 
 type DashboardReadinessZoneProps = {
   cards: DashboardReadinessCard[];
 };
 
 const endedLabel = "Закончено, идет подсчет результатов";
+
+const hasNumericReadinessValue = (
+  card: DashboardReadinessCard
+): card is DashboardReadinessCard & { keysSpent: number; totalScore: number } =>
+  typeof card.keysSpent === "number" && typeof card.totalScore === "number";
 
 export function DashboardReadinessZone({ cards }: DashboardReadinessZoneProps) {
   return (
@@ -17,7 +23,19 @@ export function DashboardReadinessZone({ cards }: DashboardReadinessZoneProps) {
         {cards.map((card) => (
           <Link key={card.activity} href={card.href} className="dashboard-readiness-card">
             <h3 className="display-face">{card.title}</h3>
-            <p>{card.primaryValue}</p>
+            {hasNumericReadinessValue(card) ? (
+              <p>
+                Ключи: <LocalizedNumber value={card.keysSpent} /> • Урон:{" "}
+                <LocalizedNumber
+                  value={card.totalScore}
+                  notation="compact"
+                  compactDisplay="short"
+                  maximumFractionDigits={1}
+                />
+              </p>
+            ) : (
+              <p>{card.primaryValue}</p>
+            )}
             <p>{card.statusLabel}</p>
             <p>
               <CountdownTimer targetIso={card.targetAt} endedLabel={endedLabel} />

--- a/apps/web/src/components/site/dashboard-trends-zone.tsx
+++ b/apps/web/src/components/site/dashboard-trends-zone.tsx
@@ -50,19 +50,21 @@ const renderTrendRows = (rows: DashboardTrendPoint[]) => {
 
 export function DashboardTrendsZone({ trends }: DashboardTrendsZoneProps) {
   return (
-    <section className="panel-card panel-card--padded dashboard-stack">
+    <section className="panel-card panel-card--padded dashboard-stack dashboard-trends-zone">
       <h2 className="display-face">Зона тренды</h2>
       <p>8-week clan trend snapshot.</p>
 
-      <article className="dashboard-stack">
-        <h3>Hydra</h3>
-        {renderTrendRows(trends.hydra)}
-      </article>
+      <div className="dashboard-trends-columns">
+        <article className="dashboard-stack">
+          <h3>Hydra</h3>
+          {renderTrendRows(trends.hydra)}
+        </article>
 
-      <article className="dashboard-stack">
-        <h3>Chimera</h3>
-        {renderTrendRows(trends.chimera)}
-      </article>
+        <article className="dashboard-stack">
+          <h3>Chimera</h3>
+          {renderTrendRows(trends.chimera)}
+        </article>
+      </div>
     </section>
   );
 }

--- a/apps/web/src/components/site/dashboard-trends-zone.tsx
+++ b/apps/web/src/components/site/dashboard-trends-zone.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { DashboardTrendPoint } from "@raid/ports";
 import { LocalizedDateTime } from "./localized-date-time";
+import { LocalizedNumber } from "./localized-number";
 
 type DashboardTrendsZoneProps = {
   trends: {
@@ -32,7 +33,14 @@ const renderTrendRows = (rows: DashboardTrendPoint[]) => {
                 style={{ width: `${widthPercent}%` }}
               />
             </div>
-            <strong>{row.totalScore.toLocaleString("en-US")}</strong>
+            <strong>
+              <LocalizedNumber
+                value={row.totalScore}
+                notation="compact"
+                compactDisplay="short"
+                maximumFractionDigits={1}
+              />
+            </strong>
           </li>
         );
       })}

--- a/apps/web/src/components/site/localized-number.test.tsx
+++ b/apps/web/src/components/site/localized-number.test.tsx
@@ -1,0 +1,52 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { LocalizedNumber } from "./localized-number";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean | undefined;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("LocalizedNumber", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("renders compact number format", async () => {
+    await act(async () => {
+      root.render(
+        <LocalizedNumber
+          value={1_200_000}
+          locale="en-US"
+          notation="compact"
+          compactDisplay="short"
+        />
+      );
+    });
+
+    expect(container.textContent).toContain("M");
+  });
+
+  it("renders locale-aware grouped number format", async () => {
+    await act(async () => {
+      root.render(<LocalizedNumber value={12_345} locale="de-DE" />);
+    });
+
+    expect(container.textContent).toBe("12.345");
+  });
+});

--- a/apps/web/src/components/site/localized-number.tsx
+++ b/apps/web/src/components/site/localized-number.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+
+type LocalizedNumberProps = {
+  value: number;
+  locale?: string;
+  notation?: Intl.NumberFormatOptions["notation"];
+  compactDisplay?: Intl.NumberFormatOptions["compactDisplay"];
+  maximumFractionDigits?: number;
+  minimumFractionDigits?: number;
+};
+
+const formatNumber = (
+  value: number,
+  locale: string | undefined,
+  options: Intl.NumberFormatOptions
+) => {
+  try {
+    return new Intl.NumberFormat(locale, options).format(value);
+  } catch {
+    return String(value);
+  }
+};
+
+export function LocalizedNumber({
+  value,
+  locale,
+  notation,
+  compactDisplay,
+  maximumFractionDigits,
+  minimumFractionDigits
+}: LocalizedNumberProps) {
+  const options = useMemo<Intl.NumberFormatOptions>(
+    () => ({
+      notation,
+      compactDisplay,
+      maximumFractionDigits,
+      minimumFractionDigits
+    }),
+    [compactDisplay, maximumFractionDigits, minimumFractionDigits, notation]
+  );
+
+  const [text, setText] = useState(() => formatNumber(value, "en-US", options));
+
+  useEffect(() => {
+    const resolvedLocale = locale ?? Intl.NumberFormat().resolvedOptions().locale;
+    setText(formatNumber(value, resolvedLocale, options));
+  }, [locale, options, value]);
+
+  return <span suppressHydrationWarning>{text}</span>;
+}

--- a/docs/superpowers/specs/2026-05-03-clan-global-results-and-trends-todo.md
+++ b/docs/superpowers/specs/2026-05-03-clan-global-results-and-trends-todo.md
@@ -1,0 +1,130 @@
+# Clan Global Results + Trends TODO
+
+Date: 2026-05-03
+Status: Backlog (not in current implementation scope)
+
+## Why this exists
+
+Current dashboard trends show only aggregate score (`total_score`) for Hydra/Chimera.
+We do not persist clan place and outcome for those windows, so UI cannot render:
+
+- place in tournament;
+- victory/defeat marker.
+
+Example source screenshots (manual capture):
+
+- `/Users/nkharche/Library/Containers/ru.keepcoder.Telegram/Data/tmp/telegram-cloud-photo-size-2-5444889964706469782-y.jpg`
+- `/Users/nkharche/Library/Containers/ru.keepcoder.Telegram/Data/tmp/telegram-cloud-photo-size-2-5449831109832151956-y.jpg`
+
+Observed fields from examples:
+
+- activity: Hydra / Chimera;
+- place (`5`);
+- keys spent (`76` / `37`);
+- clan score (`60,05B` / `36,09B`);
+- clan name + tag (`Вільне Братство [BiБр]`);
+- clan level (`19`).
+
+## Current schema gap
+
+`clan_wars_report` stores only report metadata + `has_personal_rewards`, and does not store place/outcome.
+Hydra/Chimera trends are computed only from player totals and do not include clan placement/outcome data.
+
+## Proposed data model (new)
+
+### 1) `clan_competition_leaderboard_snapshot`
+
+One snapshot per competition window for clan-level leaderboard data.
+
+Columns:
+
+- `id INTEGER PRIMARY KEY`
+- `competition_window_id INTEGER NOT NULL UNIQUE REFERENCES competition_window(id)`
+- `source_kind TEXT NOT NULL` (`game_screenshot`, `clan_chat`, `manual_json`)
+- `source_ref TEXT` (message id, file name, URL, etc.)
+- `captured_at TEXT NOT NULL` (ISO UTC capture timestamp)
+- `created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP`
+
+### 2) `clan_competition_leaderboard_entry`
+
+Rows of leaderboard positions from snapshot (top N + our clan row at minimum).
+
+Columns:
+
+- `id INTEGER PRIMARY KEY`
+- `snapshot_id INTEGER NOT NULL REFERENCES clan_competition_leaderboard_snapshot(id) ON DELETE CASCADE`
+- `place INTEGER NOT NULL CHECK (place > 0)`
+- `clan_name TEXT NOT NULL`
+- `clan_tag TEXT`
+- `clan_level INTEGER`
+- `keys_spent INTEGER CHECK (keys_spent IS NULL OR keys_spent >= 0)`
+- `total_score INTEGER NOT NULL CHECK (total_score >= 0)`
+- `is_our_clan INTEGER NOT NULL DEFAULT 0 CHECK (is_our_clan IN (0, 1))`
+- `created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP`
+
+Indexes and constraints:
+
+- `UNIQUE (snapshot_id, place)`
+- `UNIQUE (snapshot_id, clan_name, clan_tag)`
+- index on `(snapshot_id, is_our_clan)`
+
+## Outcome semantics for trends
+
+Store outcome as derived value in application layer:
+
+- `victory` when `place <= 3`;
+- `defeat` when `place > 3`;
+- `unknown` when place is missing.
+
+For Siege, prefer native `siege_report.result` (`win`/`loss`) when present.
+
+## Dashboard trends changes
+
+### Contract updates
+
+Extend trend point shape with:
+
+- `clanPlace: number | null`
+- `outcome: "victory" | "defeat" | "unknown"`
+
+### SQL/repository updates
+
+- keep existing Hydra/Chimera `total_score` aggregation;
+- join latest snapshot per `competition_window`;
+- pick `is_our_clan = 1` row to extract `place` and optional clan-level score overrides;
+- fallback to `null` place and `unknown` outcome when no snapshot exists.
+
+### UI updates (`Dashboard Trends`)
+
+Add columns:
+
+- `Place` (`#5`, `#1`, or `—`);
+- `Outcome` (`Victory` / `Defeat` / `—`).
+
+Display rule:
+
+- keep current compact number rendering for score;
+- do not block row render if place/outcome missing.
+
+## Ingestion notes
+
+Input source can be clan chat/history messages and/or screenshots.
+Need parser normalization rules for score strings:
+
+- `"60,05B"` -> `60050000000`
+- `"36,09B"` -> `36090000000`
+
+Prefer import payload schema that accepts:
+
+- activity + window (`competition_window_id` or starts/ends);
+- leaderboard entries array;
+- explicit `is_our_clan`.
+
+## TODO checklist
+
+- [ ] Add D1 migration for new leaderboard snapshot tables.
+- [ ] Add import command/path for clan-level leaderboard snapshots.
+- [ ] Add repository query for `place + outcome` per trend row.
+- [ ] Extend `@raid/ports` trend contracts with `clanPlace` and `outcome`.
+- [ ] Render new columns in `apps/web` trends zone.
+- [ ] Add tests for missing snapshot fallback and top-3 boundary (`place=3` vs `place=4`).

--- a/packages/platform/src/dashboard/create-d1-clan-dashboard-repository.ts
+++ b/packages/platform/src/dashboard/create-d1-clan-dashboard-repository.ts
@@ -54,7 +54,7 @@ const mapRankingRows = (rows: RankingRow[]): DashboardRankingRow[] =>
 
 const asNumber = (value: number | undefined) => (typeof value === "number" ? value : 0);
 
-const formatCompactNumber = (value: number) => value.toLocaleString("en-US");
+const formatNumber = (value: number) => value.toLocaleString("en-US");
 
 const computeNextBiweeklyStart = (startIso: string | null, nowIso: string): string | null => {
   if (!startIso) {
@@ -127,6 +127,10 @@ export const createD1ClanDashboardRepository = (
       const [chimeraReadiness] = chimeraReadinessRows;
       const [siegeReadiness] = siegeReadinessRows;
       const clanWarsAnchor = getClanWarsAnchorStateUtc(nowIso);
+      const hydraKeysSpent = asNumber(hydraReadiness?.keys_spent);
+      const hydraTotalScore = asNumber(hydraReadiness?.total_score);
+      const chimeraKeysSpent = asNumber(chimeraReadiness?.keys_spent);
+      const chimeraTotalScore = asNumber(chimeraReadiness?.total_score);
 
       const readiness: DashboardReadinessCard[] = [
         {
@@ -135,9 +139,9 @@ export const createD1ClanDashboardRepository = (
           targetAt: getNextHydraResetAnchorUtc(nowIso),
           targetKind: "reset",
           statusLabel: "Сброс окна",
-          primaryValue: `Ключи: ${asNumber(hydraReadiness?.keys_spent)} • Урон: ${formatCompactNumber(
-            asNumber(hydraReadiness?.total_score)
-          )}`,
+          primaryValue: `Ключи: ${hydraKeysSpent} • Урон: ${formatNumber(hydraTotalScore)}`,
+          keysSpent: hydraKeysSpent,
+          totalScore: hydraTotalScore,
           href: "/dashboard/hydra"
         },
         {
@@ -146,9 +150,9 @@ export const createD1ClanDashboardRepository = (
           targetAt: getNextChimeraResetAnchorUtc(nowIso),
           targetKind: "reset",
           statusLabel: "Сброс окна",
-          primaryValue: `Ключи: ${asNumber(chimeraReadiness?.keys_spent)} • Урон: ${formatCompactNumber(
-            asNumber(chimeraReadiness?.total_score)
-          )}`,
+          primaryValue: `Ключи: ${chimeraKeysSpent} • Урон: ${formatNumber(chimeraTotalScore)}`,
+          keysSpent: chimeraKeysSpent,
+          totalScore: chimeraTotalScore,
           href: "/dashboard/chimera"
         },
         {

--- a/packages/ports/src/repositories/clan-dashboard-repository.ts
+++ b/packages/ports/src/repositories/clan-dashboard-repository.ts
@@ -9,6 +9,8 @@ export type DashboardReadinessCard = {
   targetKind: "reset" | "start";
   statusLabel: string;
   primaryValue: string;
+  keysSpent?: number;
+  totalScore?: number;
   href: string;
 };
 


### PR DESCRIPTION
## What is included
- dashboard visual tuning: --site-panel, readiness card background, removed panel backdrop blur
- helper script to sync D1 from production to local persist store

## Why draft
This PR is opened early so we can keep stacking incremental UI and operational tweaks before final review/deploy.
