### PR TITLE
feat: add archive-first KT page and dashboard navigation

### DIFF
--- a/apps/web/src/app/dashboard/clan-wars/page.test.tsx
+++ b/apps/web/src/app/dashboard/clan-wars/page.test.tsx
@@ -3,51 +3,57 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../server/dashboard/get-clan-wars-archive-snapshot", () => ({
-  getClanWarsArchiveSnapshot: vi.fn(async () => ({
-    generatedAt: "2026-05-03T10:00:00.000Z",
-    header: {
-      targetAt: "2026-05-04T12:00:00.000Z",
-      targetKind: "start",
-      eventStartAt: "2026-05-04T12:00:00.000Z",
-      eventEndsAt: "2026-05-06T12:00:00.000Z",
-      hasPersonalRewards: true
-    },
-    history: [
-      {
-        windowStart: "2026-04-20T12:00:00.000Z",
-        windowEnd: "2026-04-22T12:00:00.000Z",
-        hasPersonalRewards: true,
-        clanTotalPoints: 1_200,
-        activeContributors: 28,
-        topPlayerName: "Alpha",
-        topPlayerPoints: 320
-      }
-    ],
-    stability: [
-      {
-        playerName: "Alpha",
-        windowsPlayed: 8,
-        avgPoints: 240,
-        bestPoints: 340,
-        lastWindowPoints: 320,
-        consistencyScore: 0.88
-      }
-    ],
-    decline: [
-      {
-        playerName: "Beta",
-        recentAvg: 90,
-        baselineAvg: 150,
-        delta: -60
-      }
-    ]
-  }))
+  getClanWarsArchiveSnapshot: vi.fn()
 }));
 
+import { getClanWarsArchiveSnapshot } from "../../../server/dashboard/get-clan-wars-archive-snapshot";
 import ClanWarsArchivePage from "./page";
+
+const getClanWarsArchiveSnapshotMock = vi.mocked(getClanWarsArchiveSnapshot);
+
+const createBaseSnapshot = () => ({
+  generatedAt: "2026-05-03T10:00:00.000Z",
+  header: {
+    targetAt: "2026-05-04T12:00:00.000Z",
+    targetKind: "start" as const,
+    eventStartAt: "2026-05-04T12:00:00.000Z",
+    eventEndsAt: "2026-05-06T12:00:00.000Z",
+    hasPersonalRewards: true
+  },
+  history: [
+    {
+      windowStart: "2026-04-20T12:00:00.000Z",
+      windowEnd: "2026-04-22T12:00:00.000Z",
+      hasPersonalRewards: true,
+      clanTotalPoints: 1_200,
+      activeContributors: 28,
+      topPlayerName: "Alpha",
+      topPlayerPoints: 320
+    }
+  ],
+  stability: [
+    {
+      playerName: "Alpha",
+      windowsPlayed: 8,
+      avgPoints: 240,
+      bestPoints: 340,
+      lastWindowPoints: 320,
+      consistencyScore: 0.88
+    }
+  ],
+  decline: [
+    {
+      playerName: "Beta",
+      recentAvg: 90,
+      baselineAvg: 150,
+      delta: -60
+    }
+  ]
+});
 
 describe("ClanWarsArchivePage", () => {
   it("renders KT archive zones and navigation", async () => {
+    getClanWarsArchiveSnapshotMock.mockResolvedValue(createBaseSnapshot());
     const html = renderToStaticMarkup(await ClanWarsArchivePage());
 
     expect(html).toContain("Клановый турнир: архив");
@@ -57,5 +63,46 @@ describe("ClanWarsArchivePage", () => {
     expect(html).toContain("Alpha");
     expect(html).toContain("Beta");
     expect(html).toContain('href="/dashboard/clan-wars"');
+  });
+
+  it("renders empty-state labels when no archive rows are available", async () => {
+    getClanWarsArchiveSnapshotMock.mockResolvedValue({
+      ...createBaseSnapshot(),
+      history: [],
+      stability: [],
+      decline: []
+    });
+
+    const html = renderToStaticMarkup(await ClanWarsArchivePage());
+
+    expect(html).toContain("Недостаточно данных");
+    expect(html).toContain("Просадок не найдено");
+  });
+
+  it("limits stability and decline rendering to top 10 rows", async () => {
+    getClanWarsArchiveSnapshotMock.mockResolvedValue({
+      ...createBaseSnapshot(),
+      stability: Array.from({ length: 11 }, (_, index) => ({
+        playerName: `Stability-${String(index + 1).padStart(2, "0")}`,
+        windowsPlayed: 12 - index,
+        avgPoints: 300 - index,
+        bestPoints: 450 - index,
+        lastWindowPoints: 280 - index,
+        consistencyScore: 0.9 - index * 0.01
+      })),
+      decline: Array.from({ length: 11 }, (_, index) => ({
+        playerName: `Decline-${String(index + 1).padStart(2, "0")}`,
+        recentAvg: 100 - index,
+        baselineAvg: 200 - index,
+        delta: -100 - index
+      }))
+    });
+
+    const html = renderToStaticMarkup(await ClanWarsArchivePage());
+
+    expect(html).toContain("Stability-10");
+    expect(html).not.toContain("Stability-11");
+    expect(html).toContain("Decline-10");
+    expect(html).not.toContain("Decline-11");
   });
 });

--- a/apps/web/src/app/dashboard/clan-wars/page.test.tsx
+++ b/apps/web/src/app/dashboard/clan-wars/page.test.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../server/dashboard/get-clan-wars-archive-snapshot", () => ({
+  getClanWarsArchiveSnapshot: vi.fn(async () => ({
+    generatedAt: "2026-05-03T10:00:00.000Z",
+    header: {
+      targetAt: "2026-05-04T12:00:00.000Z",
+      targetKind: "start",
+      eventStartAt: "2026-05-04T12:00:00.000Z",
+      eventEndsAt: "2026-05-06T12:00:00.000Z",
+      hasPersonalRewards: true
+    },
+    history: [
+      {
+        windowStart: "2026-04-20T12:00:00.000Z",
+        windowEnd: "2026-04-22T12:00:00.000Z",
+        hasPersonalRewards: true,
+        clanTotalPoints: 1_200,
+        activeContributors: 28,
+        topPlayerName: "Alpha",
+        topPlayerPoints: 320
+      }
+    ],
+    stability: [
+      {
+        playerName: "Alpha",
+        windowsPlayed: 8,
+        avgPoints: 240,
+        bestPoints: 340,
+        lastWindowPoints: 320,
+        consistencyScore: 0.88
+      }
+    ],
+    decline: [
+      {
+        playerName: "Beta",
+        recentAvg: 90,
+        baselineAvg: 150,
+        delta: -60
+      }
+    ]
+  }))
+}));
+
+import ClanWarsArchivePage from "./page";
+
+describe("ClanWarsArchivePage", () => {
+  it("renders KT archive zones and navigation", async () => {
+    const html = renderToStaticMarkup(await ClanWarsArchivePage());
+
+    expect(html).toContain("Клановый турнир: архив");
+    expect(html).toContain("История окон КТ");
+    expect(html).toContain("Стабильность состава");
+    expect(html).toContain("Кто проседает");
+    expect(html).toContain("Alpha");
+    expect(html).toContain("Beta");
+    expect(html).toContain('href="/dashboard/clan-wars"');
+  });
+});

--- a/apps/web/src/app/dashboard/clan-wars/page.tsx
+++ b/apps/web/src/app/dashboard/clan-wars/page.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { BrandMark } from "../../../components/site/brand-mark";
+import { DashboardKtDeclineZone } from "../../../components/site/dashboard-kt-decline-zone";
+import { DashboardKtHeaderZone } from "../../../components/site/dashboard-kt-header-zone";
+import { DashboardKtHistoryZone } from "../../../components/site/dashboard-kt-history-zone";
+import { DashboardKtStabilityZone } from "../../../components/site/dashboard-kt-stability-zone";
+import { DashboardNav } from "../../../components/site/dashboard-nav";
+import { getClanWarsArchiveSnapshot } from "../../../server/dashboard/get-clan-wars-archive-snapshot";
+
+export const dynamic = "force-dynamic";
+
+export default async function ClanWarsArchivePage() {
+  const snapshot = await getClanWarsArchiveSnapshot();
+
+  return (
+    <main className="dashboard-shell dashboard-shell--clan">
+      <header className="panel-card panel-card--padded dashboard-header">
+        <div className="dashboard-stack">
+          <BrandMark />
+          <h1 className="display-face">KT</h1>
+          <p>Archive-first clan wars telemetry.</p>
+          <p className="dashboard-meta">Snapshot generated: {snapshot.generatedAt}</p>
+        </div>
+        <DashboardNav />
+      </header>
+
+      <DashboardKtHeaderZone header={snapshot.header} />
+      <DashboardKtHistoryZone history={snapshot.history} />
+
+      <section className="dashboard-kt-grid">
+        <DashboardKtStabilityZone rows={snapshot.stability} />
+        <DashboardKtDeclineZone rows={snapshot.decline} />
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/app/dashboard/page.test.tsx
+++ b/apps/web/src/app/dashboard/page.test.tsx
@@ -89,6 +89,7 @@ describe("DashboardPage", () => {
     expect(html).toContain("Зона тренды");
     expect(html).toContain("Hydra");
     expect(html).toContain('aria-pressed="true">Hydra</button>');
+    expect(html).toContain('href="/dashboard/clan-wars"');
     expect(html).toContain("Слияния сейчас нет");
   });
 });

--- a/apps/web/src/app/dashboard/page.test.tsx
+++ b/apps/web/src/app/dashboard/page.test.tsx
@@ -89,7 +89,7 @@ describe("DashboardPage", () => {
     expect(html).toContain("Зона тренды");
     expect(html).toContain("Hydra");
     expect(html).toContain('aria-pressed="true">Hydra</button>');
-    expect(html).toContain('href="/dashboard/clan-wars"');
+    expect(html).toContain('<a href="/dashboard/clan-wars">KT</a>');
     expect(html).toContain("Слияния сейчас нет");
   });
 });

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -297,6 +297,30 @@ img {
   background: linear-gradient(90deg, #91a4bc, #ced8e6);
 }
 
+.dashboard-kt-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.dashboard-kt-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.dashboard-kt-table th,
+.dashboard-kt-table td {
+  border: 1px solid var(--site-border);
+  padding: 0.55rem 0.65rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.dashboard-kt-table th {
+  color: var(--site-soft);
+  font-weight: 600;
+  background: rgba(6, 8, 11, 0.62);
+}
+
 .dashboard-nav summary {
   cursor: pointer;
   list-style: none;
@@ -360,6 +384,10 @@ p {
     background-image:
       linear-gradient(180deg, rgba(6, 8, 11, 0.74), rgba(6, 8, 11, 0.9)),
       url("/images/clan-dashboard/background-desktop-dark-elves.png");
+  }
+
+  .dashboard-kt-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 

--- a/apps/web/src/components/site/dashboard-kt-decline-zone.tsx
+++ b/apps/web/src/components/site/dashboard-kt-decline-zone.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import type { ClanWarsArchiveDeclineRow } from "@raid/ports";
+
+type DashboardKtDeclineZoneProps = {
+  rows: ClanWarsArchiveDeclineRow[];
+};
+
+const formatNumber = (value: number) => value.toLocaleString("en-US");
+
+export function DashboardKtDeclineZone({ rows }: DashboardKtDeclineZoneProps) {
+  const topRows = rows.slice(0, 10);
+
+  return (
+    <section className="panel-card panel-card--padded dashboard-stack">
+      <h2 className="display-face">Кто проседает</h2>
+      {topRows.length === 0 ? (
+        <p>Просадок не найдено</p>
+      ) : (
+        <ol className="dashboard-ranking-list">
+          {topRows.map((row) => (
+            <li key={row.playerName}>
+              <span>{row.playerName}</span>
+              <strong>
+                {formatNumber(row.delta)} ({formatNumber(row.recentAvg)} vs{" "}
+                {formatNumber(row.baselineAvg)})
+              </strong>
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/site/dashboard-kt-decline-zone.tsx
+++ b/apps/web/src/components/site/dashboard-kt-decline-zone.tsx
@@ -17,8 +17,8 @@ export function DashboardKtDeclineZone({ rows }: DashboardKtDeclineZoneProps) {
         <p>Просадок не найдено</p>
       ) : (
         <ol className="dashboard-ranking-list">
-          {topRows.map((row) => (
-            <li key={row.playerName}>
+          {topRows.map((row, index) => (
+            <li key={`${row.playerName}-${index}`}>
               <span>{row.playerName}</span>
               <strong>
                 {formatNumber(row.delta)} ({formatNumber(row.recentAvg)} vs{" "}

--- a/apps/web/src/components/site/dashboard-kt-header-zone.tsx
+++ b/apps/web/src/components/site/dashboard-kt-header-zone.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import type { ClanWarsHeader } from "@raid/ports";
+import { CountdownTimer } from "./countdown-timer";
+import { LocalizedDateTime } from "./localized-date-time";
+
+type DashboardKtHeaderZoneProps = {
+  header: ClanWarsHeader;
+};
+
+const getCountdownLabel = (targetKind: ClanWarsHeader["targetKind"]) =>
+  targetKind === "start" ? "До старта следующего окна" : "До сброса текущего окна";
+
+export function DashboardKtHeaderZone({ header }: DashboardKtHeaderZoneProps) {
+  const rewardsLabel = header.hasPersonalRewards
+    ? "С личными наградами"
+    : "Без личных наград";
+
+  return (
+    <section className="panel-card panel-card--padded dashboard-stack">
+      <h2 className="display-face">Клановый турнир: архив</h2>
+      <p>
+        {getCountdownLabel(header.targetKind)}:{" "}
+        <CountdownTimer
+          targetIso={header.targetAt}
+          endedLabel="Окно завершено, ожидаем обновление"
+        />
+      </p>
+      <p>Награды: {rewardsLabel}</p>
+      <p>
+        Период окна: <LocalizedDateTime iso={header.eventStartAt} /> -{" "}
+        <LocalizedDateTime iso={header.eventEndsAt} />
+      </p>
+    </section>
+  );
+}

--- a/apps/web/src/components/site/dashboard-kt-history-zone.tsx
+++ b/apps/web/src/components/site/dashboard-kt-history-zone.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import type { ClanWarsArchiveHistoryRow } from "@raid/ports";
+import { LocalizedDateTime } from "./localized-date-time";
+
+type DashboardKtHistoryZoneProps = {
+  history: ClanWarsArchiveHistoryRow[];
+};
+
+const formatNumber = (value: number) => value.toLocaleString("en-US");
+
+export function DashboardKtHistoryZone({ history }: DashboardKtHistoryZoneProps) {
+  return (
+    <section className="panel-card panel-card--padded dashboard-stack">
+      <h2 className="display-face">История окон КТ</h2>
+      <table className="dashboard-kt-table">
+        <thead>
+          <tr>
+            <th scope="col">Окно</th>
+            <th scope="col">Награды</th>
+            <th scope="col">Очки клана</th>
+            <th scope="col">Активные</th>
+            <th scope="col">Top-1</th>
+          </tr>
+        </thead>
+        <tbody>
+          {history.length === 0 ? (
+            <tr>
+              <td colSpan={5}>Недостаточно данных</td>
+            </tr>
+          ) : (
+            history.map((row) => (
+              <tr key={row.windowStart}>
+                <td>
+                  <LocalizedDateTime iso={row.windowStart} /> -{" "}
+                  <LocalizedDateTime iso={row.windowEnd} />
+                </td>
+                <td>{row.hasPersonalRewards ? "Личные" : "Без личных"}</td>
+                <td>{formatNumber(row.clanTotalPoints)}</td>
+                <td>{formatNumber(row.activeContributors)}</td>
+                <td>
+                  {row.topPlayerName} ({formatNumber(row.topPlayerPoints)})
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </section>
+  );
+}

--- a/apps/web/src/components/site/dashboard-kt-stability-zone.tsx
+++ b/apps/web/src/components/site/dashboard-kt-stability-zone.tsx
@@ -17,8 +17,8 @@ export function DashboardKtStabilityZone({ rows }: DashboardKtStabilityZoneProps
         <p>Недостаточно данных</p>
       ) : (
         <ol className="dashboard-ranking-list">
-          {topRows.map((row) => (
-            <li key={row.playerName}>
+          {topRows.map((row, index) => (
+            <li key={`${row.playerName}-${index}`}>
               <span>{row.playerName}</span>
               <strong>
                 {formatNumber(row.avgPoints)} avg / {formatNumber(row.lastWindowPoints)} last

--- a/apps/web/src/components/site/dashboard-kt-stability-zone.tsx
+++ b/apps/web/src/components/site/dashboard-kt-stability-zone.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import type { ClanWarsArchiveStabilityRow } from "@raid/ports";
+
+type DashboardKtStabilityZoneProps = {
+  rows: ClanWarsArchiveStabilityRow[];
+};
+
+const formatNumber = (value: number) => value.toLocaleString("en-US");
+
+export function DashboardKtStabilityZone({ rows }: DashboardKtStabilityZoneProps) {
+  const topRows = rows.slice(0, 10);
+
+  return (
+    <section className="panel-card panel-card--padded dashboard-stack">
+      <h2 className="display-face">Стабильность состава</h2>
+      {topRows.length === 0 ? (
+        <p>Недостаточно данных</p>
+      ) : (
+        <ol className="dashboard-ranking-list">
+          {topRows.map((row) => (
+            <li key={row.playerName}>
+              <span>{row.playerName}</span>
+              <strong>
+                {formatNumber(row.avgPoints)} avg / {formatNumber(row.lastWindowPoints)} last
+              </strong>
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/site/dashboard-nav.tsx
+++ b/apps/web/src/components/site/dashboard-nav.tsx
@@ -8,6 +8,7 @@ export function DashboardNav() {
       <nav className="dashboard-nav__links" aria-label="Dashboard">
         <Link href="/">Landing</Link>
         <Link href="/about">About</Link>
+        <Link href="/dashboard/clan-wars">KT</Link>
       </nav>
     </details>
   );

--- a/apps/web/src/server/dashboard/get-clan-wars-archive-snapshot.ts
+++ b/apps/web/src/server/dashboard/get-clan-wars-archive-snapshot.ts
@@ -1,0 +1,14 @@
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { createGetClanWarsArchiveSnapshot } from "@raid/application";
+import { createD1ClanDashboardRepository } from "@raid/platform";
+
+export const getClanWarsArchiveSnapshot = async () => {
+  const { env } = await getCloudflareContext<Record<string, unknown> & CloudflareEnv>({
+    async: true
+  });
+
+  return createGetClanWarsArchiveSnapshot({
+    repository: createD1ClanDashboardRepository(env.DB),
+    windowLimit: 12
+  })();
+};

--- a/docs/superpowers/plans/2026-05-03-kt-archive-first-implementation.md
+++ b/docs/superpowers/plans/2026-05-03-kt-archive-first-implementation.md
@@ -1,0 +1,1103 @@
+# KT Archive-First Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `/dashboard/clan-wars` as an archive-first KT page with real historical aggregates, roster stability, decline radar, and a direct KT link in dashboard navigation.
+
+**Architecture:** Keep all DB reads in `packages/platform`, orchestration in `packages/application`, and page rendering in `apps/web`. Implement KT history queries in SQL, then compute stability/decline in a pure TypeScript metrics module to keep logic testable and deterministic. Reuse existing countdown/navigation patterns instead of introducing parallel abstractions.
+
+**Tech Stack:** TypeScript, Next.js App Router, Vitest, D1/SQLite SQL, Cloudflare runtime adapter
+
+---
+
+## Scope Check
+
+The approved spec is one subsystem: KT archive analytics page plus navigation wiring. No decomposition into additional plans is required.
+
+## File Structure Map
+
+- Modify: `packages/ports/src/repositories/clan-dashboard-repository.ts`
+- Create: `packages/platform/src/dashboard/clan-wars-archive-sql.ts`
+- Create: `packages/platform/src/dashboard/clan-wars-archive-metrics.ts`
+- Modify: `packages/platform/src/dashboard/create-d1-clan-dashboard-repository.ts`
+- Modify: `packages/platform/src/index.ts`
+- Modify: `packages/platform/test/helpers/clan-dashboard-query-check.mjs`
+- Modify: `packages/platform/test/clan-dashboard-repository.test.ts`
+- Create: `packages/platform/test/clan-wars-archive-metrics.test.ts`
+- Create: `packages/application/src/dashboard/get-clan-wars-archive-snapshot.ts`
+- Create: `packages/application/test/get-clan-wars-archive-snapshot.test.ts`
+- Modify: `packages/application/src/index.ts`
+- Create: `apps/web/src/server/dashboard/get-clan-wars-archive-snapshot.ts`
+- Create: `apps/web/src/components/site/dashboard-kt-header-zone.tsx`
+- Create: `apps/web/src/components/site/dashboard-kt-history-zone.tsx`
+- Create: `apps/web/src/components/site/dashboard-kt-stability-zone.tsx`
+- Create: `apps/web/src/components/site/dashboard-kt-decline-zone.tsx`
+- Create: `apps/web/src/app/dashboard/clan-wars/page.tsx`
+- Create: `apps/web/src/app/dashboard/clan-wars/page.test.tsx`
+- Modify: `apps/web/src/components/site/dashboard-nav.tsx`
+- Modify: `apps/web/src/app/dashboard/page.test.tsx`
+- Modify: `apps/web/src/app/globals.css`
+
+### Task 1: Add KT Archive Contracts And Pure Metrics
+
+**Files:**
+- Modify: `packages/ports/src/repositories/clan-dashboard-repository.ts`
+- Create: `packages/platform/src/dashboard/clan-wars-archive-metrics.ts`
+- Create: `packages/platform/test/clan-wars-archive-metrics.test.ts`
+- Modify: `packages/platform/src/index.ts`
+- Test: `packages/platform/test/clan-wars-archive-metrics.test.ts`
+
+- [ ] **Step 1: Write the failing metrics test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  buildClanWarsDeclineRows,
+  buildClanWarsStabilityRows,
+  type ClanWarsPlayerWindowPointsRow
+} from "@raid/platform";
+
+const rows: ClanWarsPlayerWindowPointsRow[] = [
+  { windowStart: "2031-04-07T10:00:00.000Z", playerName: "Alpha", points: 210 },
+  { windowStart: "2031-04-07T10:00:00.000Z", playerName: "Beta", points: 40 },
+  { windowStart: "2031-04-07T10:00:00.000Z", playerName: "Gamma", points: 100 },
+  { windowStart: "2031-03-24T10:00:00.000Z", playerName: "Alpha", points: 240 },
+  { windowStart: "2031-03-24T10:00:00.000Z", playerName: "Beta", points: 60 },
+  { windowStart: "2031-03-24T10:00:00.000Z", playerName: "Gamma", points: 90 },
+  { windowStart: "2031-03-10T10:00:00.000Z", playerName: "Alpha", points: 260 },
+  { windowStart: "2031-03-10T10:00:00.000Z", playerName: "Beta", points: 90 },
+  { windowStart: "2031-03-10T10:00:00.000Z", playerName: "Gamma", points: 80 },
+  { windowStart: "2031-02-24T10:00:00.000Z", playerName: "Alpha", points: 280 },
+  { windowStart: "2031-02-24T10:00:00.000Z", playerName: "Beta", points: 120 },
+  { windowStart: "2031-02-24T10:00:00.000Z", playerName: "Gamma", points: 70 },
+  { windowStart: "2031-02-10T10:00:00.000Z", playerName: "Alpha", points: 300 },
+  { windowStart: "2031-02-10T10:00:00.000Z", playerName: "Beta", points: 140 },
+  { windowStart: "2031-02-10T10:00:00.000Z", playerName: "Gamma", points: 60 },
+  { windowStart: "2031-01-27T10:00:00.000Z", playerName: "Alpha", points: 320 },
+  { windowStart: "2031-01-27T10:00:00.000Z", playerName: "Beta", points: 160 },
+  { windowStart: "2031-01-27T10:00:00.000Z", playerName: "Gamma", points: 50 }
+];
+
+describe("KT archive metrics", () => {
+  it("computes stability rows from player-window matrix", () => {
+    const stability = buildClanWarsStabilityRows(rows, 6);
+
+    expect(stability[0]).toEqual({
+      playerName: "Alpha",
+      windowsPlayed: 6,
+      avgPoints: 268.33,
+      bestPoints: 320,
+      lastWindowPoints: 210,
+      consistencyScore: 1
+    });
+  });
+
+  it("computes decline rows using recent-3 vs baseline", () => {
+    const decline = buildClanWarsDeclineRows(rows);
+
+    expect(decline[0]).toEqual({
+      playerName: "Beta",
+      recentAvg: 63.33,
+      baselineAvg: 140,
+      delta: -76.67
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test -- packages/platform/test/clan-wars-archive-metrics.test.ts`
+
+Expected: FAIL with module/type/function not found for KT archive metrics exports.
+
+- [ ] **Step 3: Add contracts and minimal metrics implementation**
+
+```ts
+// packages/ports/src/repositories/clan-dashboard-repository.ts
+export type ClanWarsHeader = {
+  targetAt: string;
+  targetKind: "start" | "reset";
+  eventStartAt: string;
+  eventEndsAt: string;
+  hasPersonalRewards: boolean;
+};
+
+export type ClanWarsArchiveHistoryRow = {
+  windowStart: string;
+  windowEnd: string;
+  hasPersonalRewards: boolean;
+  clanTotalPoints: number;
+  activeContributors: number;
+  topPlayerName: string;
+  topPlayerPoints: number;
+};
+
+export type ClanWarsArchiveStabilityRow = {
+  playerName: string;
+  windowsPlayed: number;
+  avgPoints: number;
+  bestPoints: number;
+  lastWindowPoints: number;
+  consistencyScore: number;
+};
+
+export type ClanWarsArchiveDeclineRow = {
+  playerName: string;
+  recentAvg: number;
+  baselineAvg: number;
+  delta: number;
+};
+
+export type ClanWarsArchiveData = {
+  header: ClanWarsHeader;
+  history: ClanWarsArchiveHistoryRow[];
+  stability: ClanWarsArchiveStabilityRow[];
+  decline: ClanWarsArchiveDeclineRow[];
+};
+
+export type ClanWarsArchiveRepository = {
+  getClanWarsArchive(input: { nowIso: string; windowLimit: number }): Promise<ClanWarsArchiveData>;
+};
+```
+
+```ts
+// packages/platform/src/dashboard/clan-wars-archive-metrics.ts
+import type {
+  ClanWarsArchiveDeclineRow,
+  ClanWarsArchiveStabilityRow
+} from "@raid/ports";
+
+export type ClanWarsPlayerWindowPointsRow = {
+  windowStart: string;
+  playerName: string;
+  points: number;
+};
+
+const round2 = (value: number) => Math.round(value * 100) / 100;
+
+const getSortedWindowsDesc = (rows: ClanWarsPlayerWindowPointsRow[]) =>
+  Array.from(new Set(rows.map((row) => row.windowStart))).sort((a, b) =>
+    a < b ? 1 : a > b ? -1 : 0
+  );
+
+const groupPlayerPoints = (rows: ClanWarsPlayerWindowPointsRow[]) => {
+  const grouped = new Map<string, Map<string, number>>();
+
+  for (const row of rows) {
+    const perPlayer = grouped.get(row.playerName) ?? new Map<string, number>();
+    perPlayer.set(row.windowStart, row.points);
+    grouped.set(row.playerName, perPlayer);
+  }
+
+  return grouped;
+};
+
+export const buildClanWarsStabilityRows = (
+  rows: ClanWarsPlayerWindowPointsRow[],
+  selectedWindows: number
+): ClanWarsArchiveStabilityRow[] => {
+  const windows = getSortedWindowsDesc(rows).slice(0, selectedWindows);
+  const grouped = groupPlayerPoints(rows);
+
+  return Array.from(grouped.entries())
+    .map(([playerName, pointsByWindow]) => {
+      const values = windows.map((windowStart) => pointsByWindow.get(windowStart) ?? 0);
+      const windowsPlayed = values.filter((points) => points > 0).length;
+      const avgPoints = values.length === 0 ? 0 : round2(values.reduce((sum, value) => sum + value, 0) / values.length);
+      const bestPoints =
+        values.length === 0
+          ? 0
+          : values.reduce((maxValue, currentValue) =>
+              currentValue > maxValue ? currentValue : maxValue
+            , values[0]);
+      const lastWindowPoints = values.length === 0 ? 0 : values[0];
+      const consistencyScore = values.length === 0 ? 0 : round2(windowsPlayed / values.length);
+
+      return {
+        playerName,
+        windowsPlayed,
+        avgPoints,
+        bestPoints,
+        lastWindowPoints,
+        consistencyScore
+      };
+    })
+    .sort((a, b) =>
+      b.consistencyScore - a.consistencyScore ||
+      b.avgPoints - a.avgPoints ||
+      a.playerName.localeCompare(b.playerName)
+    );
+};
+
+export const buildClanWarsDeclineRows = (
+  rows: ClanWarsPlayerWindowPointsRow[]
+): ClanWarsArchiveDeclineRow[] => {
+  const windows = getSortedWindowsDesc(rows);
+  const recentWindows = windows.slice(0, 3);
+  const precedingWindows = windows.slice(3);
+  const baselineWindows =
+    precedingWindows.length > 6 ? precedingWindows.slice(0, 6) : precedingWindows;
+  const grouped = groupPlayerPoints(rows);
+
+  if (recentWindows.length < 3 || baselineWindows.length === 0) {
+    return [];
+  }
+
+  return Array.from(grouped.entries())
+    .map(([playerName, pointsByWindow]) => {
+      const recentValues = recentWindows.map((windowStart) => pointsByWindow.get(windowStart) ?? 0);
+      const baselineValues = baselineWindows.map((windowStart) => pointsByWindow.get(windowStart) ?? 0);
+      const windowsPlayed = windows.filter((windowStart) => (pointsByWindow.get(windowStart) ?? 0) > 0).length;
+
+      if (windowsPlayed < 3) {
+        return null;
+      }
+
+      const recentAvg = round2(recentValues.reduce((sum, value) => sum + value, 0) / recentValues.length);
+      const baselineAvg = round2(
+        baselineValues.reduce((sum, value) => sum + value, 0) / baselineValues.length
+      );
+      const delta = round2(recentAvg - baselineAvg);
+
+      return { playerName, recentAvg, baselineAvg, delta };
+    })
+    .filter((row): row is ClanWarsArchiveDeclineRow => row !== null && row.delta < 0)
+    .sort((a, b) => a.delta - b.delta || a.playerName.localeCompare(b.playerName));
+};
+```
+
+```ts
+// packages/platform/src/index.ts
+export * from "./dashboard/clan-wars-archive-metrics";
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test -- packages/platform/test/clan-wars-archive-metrics.test.ts`
+
+Expected: PASS with both stability and decline cases green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ports/src/repositories/clan-dashboard-repository.ts \
+  packages/platform/src/dashboard/clan-wars-archive-metrics.ts \
+  packages/platform/src/index.ts \
+  packages/platform/test/clan-wars-archive-metrics.test.ts
+git commit -m "feat: add KT archive metric contracts and calculators"
+```
+
+### Task 2: Add KT Archive SQL And Repository Integration
+
+**Files:**
+- Create: `packages/platform/src/dashboard/clan-wars-archive-sql.ts`
+- Modify: `packages/platform/src/dashboard/create-d1-clan-dashboard-repository.ts`
+- Modify: `packages/platform/src/index.ts`
+- Modify: `packages/platform/test/helpers/clan-dashboard-query-check.mjs`
+- Modify: `packages/platform/test/clan-dashboard-repository.test.ts`
+- Test: `packages/platform/test/clan-dashboard-repository.test.ts`
+
+- [ ] **Step 1: Add failing repository query test**
+
+```ts
+// packages/platform/test/clan-dashboard-repository.test.ts
+it("aggregates KT archive history rows with contributors and top player", () => {
+  const result = runCheck<{
+    ok: boolean;
+    rows: Array<{
+      starts_at: string;
+      has_personal_rewards: number;
+      clan_total_points: number;
+      active_contributors: number;
+      top_player_name: string;
+      top_player_points: number;
+    }>;
+  }>("kt-archive-history-aggregate");
+
+  expect(result.ok).toBe(true);
+  expect(result.rows[0]).toEqual({
+    starts_at: "2031-04-12T00:00:00Z",
+    has_personal_rewards: 1,
+    clan_total_points: 430,
+    active_contributors: 3,
+    top_player_name: "Alpha",
+    top_player_points: 220
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test -- packages/platform/test/clan-dashboard-repository.test.ts`
+
+Expected: FAIL with `unknown-command:kt-archive-history-aggregate`.
+
+- [ ] **Step 3: Implement KT archive SQL + repository method + helper command**
+
+```ts
+// packages/platform/src/dashboard/clan-wars-archive-sql.ts
+export const selectClanWarsArchiveHistorySql = `
+WITH recent_windows AS (
+  SELECT id, starts_at, ends_at
+  FROM competition_window
+  WHERE activity_type = 'clan_wars'
+  ORDER BY starts_at DESC, id DESC
+  LIMIT ?
+)
+SELECT
+  rw.id AS window_id,
+  rw.starts_at,
+  rw.ends_at,
+  COALESCE(cwr.has_personal_rewards, 0) AS has_personal_rewards,
+  COALESCE(SUM(cwps.points), 0) AS clan_total_points,
+  COALESCE(COUNT(DISTINCT CASE WHEN cwps.points > 0 THEN cwps.player_profile_id END), 0) AS active_contributors,
+  COALESCE((
+    SELECT pp2.main_nickname
+    FROM clan_wars_player_score cwps2
+    JOIN player_profile pp2 ON pp2.id = cwps2.player_profile_id
+    WHERE cwps2.competition_window_id = rw.id
+    ORDER BY cwps2.points DESC, pp2.main_nickname ASC
+    LIMIT 1
+  ), '—') AS top_player_name,
+  COALESCE((
+    SELECT cwps2.points
+    FROM clan_wars_player_score cwps2
+    JOIN player_profile pp2 ON pp2.id = cwps2.player_profile_id
+    WHERE cwps2.competition_window_id = rw.id
+    ORDER BY cwps2.points DESC, pp2.main_nickname ASC
+    LIMIT 1
+  ), 0) AS top_player_points
+FROM recent_windows rw
+LEFT JOIN clan_wars_report cwr ON cwr.competition_window_id = rw.id
+LEFT JOIN clan_wars_player_score cwps ON cwps.competition_window_id = rw.id
+GROUP BY rw.id, rw.starts_at, rw.ends_at, cwr.has_personal_rewards
+ORDER BY rw.starts_at DESC, rw.id DESC;
+`;
+
+export const selectClanWarsArchivePlayerWindowSql = `
+WITH recent_windows AS (
+  SELECT id, starts_at
+  FROM competition_window
+  WHERE activity_type = 'clan_wars'
+  ORDER BY starts_at DESC, id DESC
+  LIMIT ?
+), active_players AS (
+  SELECT id, main_nickname
+  FROM player_profile
+  WHERE status = 'active'
+)
+SELECT
+  rw.starts_at AS window_start,
+  ap.main_nickname AS player_name,
+  COALESCE(cwps.points, 0) AS points
+FROM recent_windows rw
+CROSS JOIN active_players ap
+LEFT JOIN clan_wars_player_score cwps
+  ON cwps.competition_window_id = rw.id
+  AND cwps.player_profile_id = ap.id
+ORDER BY rw.starts_at DESC, ap.main_nickname ASC;
+`;
+```
+
+```ts
+// packages/platform/src/dashboard/create-d1-clan-dashboard-repository.ts
+import { buildClanWarsDeclineRows, buildClanWarsStabilityRows, type ClanWarsPlayerWindowPointsRow } from "./clan-wars-archive-metrics";
+import { selectClanWarsArchiveHistorySql, selectClanWarsArchivePlayerWindowSql } from "./clan-wars-archive-sql";
+
+type ClanWarsArchiveHistoryRow = {
+  starts_at: string;
+  ends_at: string;
+  has_personal_rewards: number;
+  clan_total_points: number;
+  active_contributors: number;
+  top_player_name: string;
+  top_player_points: number;
+};
+
+type ClanWarsArchivePlayerWindowDbRow = {
+  window_start: string;
+  player_name: string;
+  points: number;
+};
+
+// inside returned object:
+async getClanWarsArchive({ nowIso, windowLimit }) {
+  const [historyRows, playerWindowRows] = await Promise.all([
+    queryRows<ClanWarsArchiveHistoryRow>(selectClanWarsArchiveHistorySql, windowLimit),
+    queryRows<ClanWarsArchivePlayerWindowDbRow>(selectClanWarsArchivePlayerWindowSql, windowLimit)
+  ]);
+
+  const clanWarsAnchor = getClanWarsAnchorStateUtc(nowIso);
+  const playerRows: ClanWarsPlayerWindowPointsRow[] = playerWindowRows.map((row) => ({
+    windowStart: row.window_start,
+    playerName: row.player_name,
+    points: row.points
+  }));
+
+  return {
+    header: {
+      targetAt: clanWarsAnchor.targetAt,
+      targetKind: clanWarsAnchor.targetKind,
+      eventStartAt: clanWarsAnchor.eventStartAt,
+      eventEndsAt: clanWarsAnchor.eventEndsAt,
+      hasPersonalRewards: clanWarsAnchor.hasPersonalRewards
+    },
+    history: historyRows.map((row) => ({
+      windowStart: row.starts_at,
+      windowEnd: row.ends_at,
+      hasPersonalRewards: row.has_personal_rewards === 1,
+      clanTotalPoints: row.clan_total_points,
+      activeContributors: row.active_contributors,
+      topPlayerName: row.top_player_name,
+      topPlayerPoints: row.top_player_points
+    })),
+    stability: buildClanWarsStabilityRows(playerRows, windowLimit),
+    decline: buildClanWarsDeclineRows(playerRows)
+  };
+}
+```
+
+```ts
+// packages/platform/test/helpers/clan-dashboard-query-check.mjs (new command)
+const selectClanWarsArchiveHistorySql = `
+WITH recent_windows AS (
+  SELECT id, starts_at, ends_at
+  FROM competition_window
+  WHERE activity_type = 'clan_wars'
+  ORDER BY starts_at DESC, id DESC
+  LIMIT ?
+)
+SELECT
+  rw.starts_at,
+  COALESCE(cwr.has_personal_rewards, 0) AS has_personal_rewards,
+  COALESCE(SUM(cwps.points), 0) AS clan_total_points,
+  COALESCE(COUNT(DISTINCT CASE WHEN cwps.points > 0 THEN cwps.player_profile_id END), 0) AS active_contributors,
+  COALESCE((
+    SELECT pp2.main_nickname
+    FROM clan_wars_player_score cwps2
+    JOIN player_profile pp2 ON pp2.id = cwps2.player_profile_id
+    WHERE cwps2.competition_window_id = rw.id
+    ORDER BY cwps2.points DESC, pp2.main_nickname ASC
+    LIMIT 1
+  ), '—') AS top_player_name,
+  COALESCE((
+    SELECT cwps2.points
+    FROM clan_wars_player_score cwps2
+    JOIN player_profile pp2 ON pp2.id = cwps2.player_profile_id
+    WHERE cwps2.competition_window_id = rw.id
+    ORDER BY cwps2.points DESC, pp2.main_nickname ASC
+    LIMIT 1
+  ), 0) AS top_player_points
+FROM recent_windows rw
+LEFT JOIN clan_wars_report cwr ON cwr.competition_window_id = rw.id
+LEFT JOIN clan_wars_player_score cwps ON cwps.competition_window_id = rw.id
+GROUP BY rw.id, rw.starts_at, cwr.has_personal_rewards
+ORDER BY rw.starts_at DESC, rw.id DESC;
+`;
+
+const runKtArchiveHistoryAggregate = (database) => {
+  const alpha = insertPlayer(database, "Alpha");
+  const beta = insertPlayer(database, "Beta");
+  const gamma = insertPlayer(database, "Gamma");
+
+  const firstWindow = insertCompetitionWindow(database, {
+    activityType: "clan_wars",
+    seasonYear: 2031,
+    week: 11,
+    cadence: "biweekly",
+    rotationNumber: null,
+    startsAt: "2031-04-12T00:00:00Z",
+    endsAt: "2031-04-14T00:00:00Z",
+    label: "cw-a"
+  });
+
+  const secondWindow = insertCompetitionWindow(database, {
+    activityType: "clan_wars",
+    seasonYear: 2031,
+    week: 10,
+    cadence: "biweekly",
+    rotationNumber: null,
+    startsAt: "2031-03-29T00:00:00Z",
+    endsAt: "2031-03-31T00:00:00Z",
+    label: "cw-b"
+  });
+
+  const firstImport = insertReportImport(database, "cw-a");
+  const secondImport = insertReportImport(database, "cw-b");
+
+  const firstReportId = Number(
+    database.prepare("INSERT INTO clan_wars_report (competition_window_id, report_import_id, source_system, is_partial, has_personal_rewards, created_at) VALUES (?, ?, ?, ?, ?, ?)").run(
+      firstWindow,
+      firstImport,
+      "unit",
+      0,
+      1,
+      "2031-04-12T02:00:00Z"
+    ).lastInsertRowid
+  );
+  const secondReportId = Number(
+    database.prepare("INSERT INTO clan_wars_report (competition_window_id, report_import_id, source_system, is_partial, has_personal_rewards, created_at) VALUES (?, ?, ?, ?, ?, ?)").run(
+      secondWindow,
+      secondImport,
+      "unit",
+      0,
+      0,
+      "2031-03-29T02:00:00Z"
+    ).lastInsertRowid
+  );
+
+  database.prepare("INSERT INTO clan_wars_player_score (clan_wars_report_id, competition_window_id, player_profile_id, display_name_at_import, points) VALUES (?, ?, ?, ?, ?)").run(firstReportId, firstWindow, alpha, "Alpha", 220);
+  database.prepare("INSERT INTO clan_wars_player_score (clan_wars_report_id, competition_window_id, player_profile_id, display_name_at_import, points) VALUES (?, ?, ?, ?, ?)").run(firstReportId, firstWindow, beta, "Beta", 110);
+  database.prepare("INSERT INTO clan_wars_player_score (clan_wars_report_id, competition_window_id, player_profile_id, display_name_at_import, points) VALUES (?, ?, ?, ?, ?)").run(firstReportId, firstWindow, gamma, "Gamma", 100);
+  database.prepare("INSERT INTO clan_wars_player_score (clan_wars_report_id, competition_window_id, player_profile_id, display_name_at_import, points) VALUES (?, ?, ?, ?, ?)").run(secondReportId, secondWindow, alpha, "Alpha", 180);
+  database.prepare("INSERT INTO clan_wars_player_score (clan_wars_report_id, competition_window_id, player_profile_id, display_name_at_import, points) VALUES (?, ?, ?, ?, ?)").run(secondReportId, secondWindow, beta, "Beta", 50);
+
+  const rows = database.prepare(selectClanWarsArchiveHistorySql).all(12);
+  emit({ ok: true, rows });
+};
+
+// in switch(command)
+case "kt-archive-history-aggregate":
+  runKtArchiveHistoryAggregate(database);
+  break;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test -- packages/platform/test/clan-dashboard-repository.test.ts`
+
+Expected: PASS with existing 3 tests plus new KT archive aggregation test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/platform/src/dashboard/clan-wars-archive-sql.ts \
+  packages/platform/src/dashboard/create-d1-clan-dashboard-repository.ts \
+  packages/platform/src/index.ts \
+  packages/platform/test/helpers/clan-dashboard-query-check.mjs \
+  packages/platform/test/clan-dashboard-repository.test.ts
+git commit -m "feat: add KT archive SQL and D1 repository snapshot"
+```
+
+### Task 3: Add Application Use Case For KT Archive Snapshot
+
+**Files:**
+- Create: `packages/application/src/dashboard/get-clan-wars-archive-snapshot.ts`
+- Create: `packages/application/test/get-clan-wars-archive-snapshot.test.ts`
+- Modify: `packages/application/src/index.ts`
+- Test: `packages/application/test/get-clan-wars-archive-snapshot.test.ts`
+
+- [ ] **Step 1: Write the failing application test**
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import { createGetClanWarsArchiveSnapshot } from "@raid/application";
+import type { ClanWarsArchiveRepository } from "@raid/ports";
+
+describe("createGetClanWarsArchiveSnapshot", () => {
+  it("returns generatedAt plus KT archive data from repository", async () => {
+    const repository: ClanWarsArchiveRepository = {
+      getClanWarsArchive: vi.fn(async () => ({
+        header: {
+          targetAt: "2026-05-05T10:00:00.000Z",
+          targetKind: "start",
+          eventStartAt: "2026-05-05T10:00:00.000Z",
+          eventEndsAt: "2026-05-07T10:00:00.000Z",
+          hasPersonalRewards: true
+        },
+        history: [],
+        stability: [],
+        decline: []
+      }))
+    };
+
+    const getSnapshot = createGetClanWarsArchiveSnapshot({
+      repository,
+      now: () => new Date("2026-05-03T14:00:00.000Z"),
+      windowLimit: 12
+    });
+
+    const snapshot = await getSnapshot();
+
+    expect(repository.getClanWarsArchive).toHaveBeenCalledWith({
+      nowIso: "2026-05-03T14:00:00.000Z",
+      windowLimit: 12
+    });
+    expect(snapshot.generatedAt).toBe("2026-05-03T14:00:00.000Z");
+    expect(snapshot.header.targetKind).toBe("start");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test -- packages/application/test/get-clan-wars-archive-snapshot.test.ts`
+
+Expected: FAIL because `createGetClanWarsArchiveSnapshot` does not exist yet.
+
+- [ ] **Step 3: Implement KT archive application use case**
+
+```ts
+// packages/application/src/dashboard/get-clan-wars-archive-snapshot.ts
+import type { ClanWarsArchiveData, ClanWarsArchiveRepository } from "@raid/ports";
+
+export type ClanWarsArchiveSnapshot = ClanWarsArchiveData & {
+  generatedAt: string;
+};
+
+export type GetClanWarsArchiveSnapshotDeps = {
+  repository: ClanWarsArchiveRepository;
+  now?: () => Date;
+  windowLimit?: number;
+};
+
+export const createGetClanWarsArchiveSnapshot = ({
+  repository,
+  now = () => new Date(),
+  windowLimit = 12
+}: GetClanWarsArchiveSnapshotDeps) => {
+  return async (): Promise<ClanWarsArchiveSnapshot> => {
+    const nowIso = now().toISOString();
+    const data = await repository.getClanWarsArchive({
+      nowIso,
+      windowLimit
+    });
+
+    return {
+      generatedAt: nowIso,
+      header: data.header,
+      history: data.history,
+      stability: data.stability,
+      decline: data.decline
+    };
+  };
+};
+```
+
+```ts
+// packages/application/src/index.ts
+export * from "./dashboard/get-clan-wars-archive-snapshot";
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test -- packages/application/test/get-clan-wars-archive-snapshot.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/application/src/dashboard/get-clan-wars-archive-snapshot.ts \
+  packages/application/src/index.ts \
+  packages/application/test/get-clan-wars-archive-snapshot.test.ts
+git commit -m "feat: add KT archive application snapshot use case"
+```
+
+### Task 4: Add KT Page, Components, Navigation Link, and UI Tests
+
+**Files:**
+- Create: `apps/web/src/server/dashboard/get-clan-wars-archive-snapshot.ts`
+- Create: `apps/web/src/components/site/dashboard-kt-header-zone.tsx`
+- Create: `apps/web/src/components/site/dashboard-kt-history-zone.tsx`
+- Create: `apps/web/src/components/site/dashboard-kt-stability-zone.tsx`
+- Create: `apps/web/src/components/site/dashboard-kt-decline-zone.tsx`
+- Create: `apps/web/src/app/dashboard/clan-wars/page.tsx`
+- Create: `apps/web/src/app/dashboard/clan-wars/page.test.tsx`
+- Modify: `apps/web/src/components/site/dashboard-nav.tsx`
+- Modify: `apps/web/src/app/dashboard/page.test.tsx`
+- Modify: `apps/web/src/app/globals.css`
+- Test: `apps/web/src/app/dashboard/clan-wars/page.test.tsx`
+- Test: `apps/web/src/app/dashboard/page.test.tsx`
+
+- [ ] **Step 1: Write failing KT page render test**
+
+```ts
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../server/dashboard/get-clan-wars-archive-snapshot", () => ({
+  getClanWarsArchiveSnapshot: vi.fn(async () => ({
+    generatedAt: "2026-05-03T14:00:00.000Z",
+    header: {
+      targetAt: "2026-05-05T10:00:00.000Z",
+      targetKind: "start",
+      eventStartAt: "2026-05-05T10:00:00.000Z",
+      eventEndsAt: "2026-05-07T10:00:00.000Z",
+      hasPersonalRewards: true
+    },
+    history: [
+      {
+        windowStart: "2026-04-21T10:00:00.000Z",
+        windowEnd: "2026-04-23T10:00:00.000Z",
+        hasPersonalRewards: true,
+        clanTotalPoints: 4100,
+        activeContributors: 28,
+        topPlayerName: "Alpha",
+        topPlayerPoints: 420
+      }
+    ],
+    stability: [
+      {
+        playerName: "Alpha",
+        windowsPlayed: 12,
+        avgPoints: 301.2,
+        bestPoints: 440,
+        lastWindowPoints: 420,
+        consistencyScore: 1
+      }
+    ],
+    decline: [
+      {
+        playerName: "Beta",
+        recentAvg: 145,
+        baselineAvg: 220,
+        delta: -75
+      }
+    ]
+  }))
+}));
+
+import ClanWarsPage from "./page";
+
+describe("ClanWarsPage", () => {
+  it("renders archive-first KT blocks and nav link", async () => {
+    const html = renderToStaticMarkup(await ClanWarsPage());
+
+    expect(html).toContain("Клановый турнир: архив");
+    expect(html).toContain("История окон КТ");
+    expect(html).toContain("Стабильность состава");
+    expect(html).toContain("Кто проседает");
+    expect(html).toContain("Alpha");
+    expect(html).toContain("Beta");
+    expect(html).toContain('href="/dashboard/clan-wars"');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test -- apps/web/src/app/dashboard/clan-wars/page.test.tsx`
+
+Expected: FAIL because route/components/server loader are missing.
+
+- [ ] **Step 3: Implement route, server loader, KT components, and nav link**
+
+```ts
+// apps/web/src/server/dashboard/get-clan-wars-archive-snapshot.ts
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { createGetClanWarsArchiveSnapshot } from "@raid/application";
+import { createD1ClanDashboardRepository } from "@raid/platform";
+
+export const getClanWarsArchiveSnapshot = async () => {
+  const { env } = await getCloudflareContext<Record<string, unknown> & CloudflareEnv>({
+    async: true
+  });
+
+  return createGetClanWarsArchiveSnapshot({
+    repository: createD1ClanDashboardRepository(env.DB),
+    windowLimit: 12
+  })();
+};
+```
+
+```tsx
+// apps/web/src/components/site/dashboard-kt-header-zone.tsx
+import React from "react";
+import type { ClanWarsHeader } from "@raid/ports";
+import { CountdownTimer } from "./countdown-timer";
+import { LocalizedDateTime } from "./localized-date-time";
+
+type DashboardKtHeaderZoneProps = {
+  header: ClanWarsHeader;
+};
+
+export function DashboardKtHeaderZone({ header }: DashboardKtHeaderZoneProps) {
+  const statusLabel =
+    header.targetKind === "start" ? "До начала следующего КТ" : "До конца текущего КТ";
+
+  return (
+    <section className="panel-card panel-card--padded dashboard-stack">
+      <h2 className="display-face">Клановый турнир: архив</h2>
+      <p>{statusLabel}</p>
+      <p>
+        <CountdownTimer
+          targetIso={header.targetAt}
+          endedLabel="Закончено, идет подсчет результатов"
+        />
+      </p>
+      <p>Личные награды: {header.hasPersonalRewards ? "с личными наградами" : "без"}</p>
+      <p>
+        Окно: <LocalizedDateTime iso={header.eventStartAt} /> -{" "}
+        <LocalizedDateTime iso={header.eventEndsAt} />
+      </p>
+    </section>
+  );
+}
+```
+
+```tsx
+// apps/web/src/app/dashboard/clan-wars/page.tsx
+import React from "react";
+import { BrandMark } from "../../../components/site/brand-mark";
+import { DashboardKtDeclineZone } from "../../../components/site/dashboard-kt-decline-zone";
+import { DashboardKtHeaderZone } from "../../../components/site/dashboard-kt-header-zone";
+import { DashboardKtHistoryZone } from "../../../components/site/dashboard-kt-history-zone";
+import { DashboardKtStabilityZone } from "../../../components/site/dashboard-kt-stability-zone";
+import { DashboardNav } from "../../../components/site/dashboard-nav";
+import { getClanWarsArchiveSnapshot } from "../../../server/dashboard/get-clan-wars-archive-snapshot";
+
+export const dynamic = "force-dynamic";
+
+export default async function ClanWarsPage() {
+  const snapshot = await getClanWarsArchiveSnapshot();
+
+  return (
+    <main className="dashboard-shell dashboard-shell--clan">
+      <header className="panel-card panel-card--padded dashboard-header">
+        <div className="dashboard-stack">
+          <BrandMark />
+          <h1 className="display-face">KT</h1>
+          <p className="dashboard-meta">Snapshot generated: {snapshot.generatedAt}</p>
+        </div>
+        <DashboardNav />
+      </header>
+
+      <DashboardKtHeaderZone header={snapshot.header} />
+      <DashboardKtHistoryZone rows={snapshot.history} />
+      <div className="dashboard-kt-grid">
+        <DashboardKtStabilityZone rows={snapshot.stability} />
+        <DashboardKtDeclineZone rows={snapshot.decline} />
+      </div>
+    </main>
+  );
+}
+```
+
+```tsx
+// apps/web/src/components/site/dashboard-kt-history-zone.tsx
+import React from "react";
+import type { ClanWarsArchiveHistoryRow } from "@raid/ports";
+import { LocalizedDateTime } from "./localized-date-time";
+
+type DashboardKtHistoryZoneProps = {
+  rows: ClanWarsArchiveHistoryRow[];
+};
+
+export function DashboardKtHistoryZone({ rows }: DashboardKtHistoryZoneProps) {
+  return (
+    <section className="panel-card panel-card--padded dashboard-stack">
+      <h2 className="display-face">История окон КТ</h2>
+      <table className="dashboard-kt-table">
+        <thead>
+          <tr>
+            <th>Окно</th>
+            <th>Лички</th>
+            <th>Очки клана</th>
+            <th>Активные</th>
+            <th>Топ-1</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.windowStart}>
+              <td>
+                <LocalizedDateTime iso={row.windowStart} /> -{" "}
+                <LocalizedDateTime iso={row.windowEnd} />
+              </td>
+              <td>{row.hasPersonalRewards ? "да" : "нет"}</td>
+              <td>{row.clanTotalPoints.toLocaleString("en-US")}</td>
+              <td>{row.activeContributors}</td>
+              <td>
+                {row.topPlayerName} ({row.topPlayerPoints.toLocaleString("en-US")})
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}
+```
+
+```tsx
+// apps/web/src/components/site/dashboard-kt-stability-zone.tsx
+import React from "react";
+import type { ClanWarsArchiveStabilityRow } from "@raid/ports";
+
+type DashboardKtStabilityZoneProps = {
+  rows: ClanWarsArchiveStabilityRow[];
+};
+
+export function DashboardKtStabilityZone({ rows }: DashboardKtStabilityZoneProps) {
+  return (
+    <section className="panel-card panel-card--padded dashboard-stack">
+      <h2 className="display-face">Стабильность состава</h2>
+      <ul className="dashboard-ranking-list">
+        {rows.slice(0, 10).map((row) => (
+          <li key={row.playerName}>
+            <span>
+              {row.playerName} ({row.windowsPlayed} окон, score {row.consistencyScore})
+            </span>
+            <span>{row.avgPoints.toLocaleString("en-US")}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+```
+
+```tsx
+// apps/web/src/components/site/dashboard-kt-decline-zone.tsx
+import React from "react";
+import type { ClanWarsArchiveDeclineRow } from "@raid/ports";
+
+type DashboardKtDeclineZoneProps = {
+  rows: ClanWarsArchiveDeclineRow[];
+};
+
+export function DashboardKtDeclineZone({ rows }: DashboardKtDeclineZoneProps) {
+  return (
+    <section className="panel-card panel-card--padded dashboard-stack">
+      <h2 className="display-face">Кто проседает</h2>
+      <ul className="dashboard-ranking-list">
+        {rows.slice(0, 10).map((row) => (
+          <li key={row.playerName}>
+            <span>{row.playerName}</span>
+            <span>
+              {row.recentAvg.toLocaleString("en-US")} vs {row.baselineAvg.toLocaleString("en-US")} (
+              {row.delta.toLocaleString("en-US")})
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+```
+
+```tsx
+// apps/web/src/components/site/dashboard-nav.tsx
+import React from "react";
+import Link from "next/link";
+
+export function DashboardNav() {
+  return (
+    <details className="dashboard-nav">
+      <summary>Menu</summary>
+      <nav className="dashboard-nav__links" aria-label="Dashboard">
+        <Link href="/">Landing</Link>
+        <Link href="/dashboard/clan-wars">KT</Link>
+        <Link href="/about">About</Link>
+      </nav>
+    </details>
+  );
+}
+```
+
+```ts
+// apps/web/src/app/dashboard/page.test.tsx (append in existing test)
+expect(html).toContain('href="/dashboard/clan-wars"');
+```
+
+```css
+/* apps/web/src/app/globals.css */
+.dashboard-kt-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.dashboard-kt-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.dashboard-kt-table th,
+.dashboard-kt-table td {
+  border-bottom: 1px solid var(--site-border);
+  padding: 0.5rem;
+  text-align: left;
+}
+
+@media (min-width: 901px) {
+  .dashboard-kt-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+```
+
+- [ ] **Step 4: Run page tests to verify they pass**
+
+Run: `pnpm test -- apps/web/src/app/dashboard/clan-wars/page.test.tsx apps/web/src/app/dashboard/page.test.tsx`
+
+Expected: PASS with KT page rendering and dashboard nav link assertions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/server/dashboard/get-clan-wars-archive-snapshot.ts \
+  apps/web/src/components/site/dashboard-kt-header-zone.tsx \
+  apps/web/src/components/site/dashboard-kt-history-zone.tsx \
+  apps/web/src/components/site/dashboard-kt-stability-zone.tsx \
+  apps/web/src/components/site/dashboard-kt-decline-zone.tsx \
+  apps/web/src/app/dashboard/clan-wars/page.tsx \
+  apps/web/src/app/dashboard/clan-wars/page.test.tsx \
+  apps/web/src/components/site/dashboard-nav.tsx \
+  apps/web/src/app/dashboard/page.test.tsx \
+  apps/web/src/app/globals.css
+git commit -m "feat: add archive-first KT page and dashboard KT navigation"
+```
+
+### Task 5: Full Verification Gate For KT Archive Rollout
+
+**Files:**
+- Modify: none unless failures require targeted fixes
+- Test: repository-wide validation commands
+
+- [ ] **Step 1: Run focused suite for changed areas**
+
+Run:
+
+```bash
+pnpm test -- packages/platform/test/clan-wars-archive-metrics.test.ts \
+  packages/platform/test/clan-dashboard-repository.test.ts \
+  packages/application/test/get-clan-wars-archive-snapshot.test.ts \
+  apps/web/src/app/dashboard/clan-wars/page.test.tsx \
+  apps/web/src/app/dashboard/page.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm typecheck`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `pnpm test`
+
+Expected: PASS without regressions.
+
+- [ ] **Step 4: Run baseline build gates**
+
+Run:
+
+```bash
+pnpm -r run build
+pnpm --filter @raid/web run cf:build
+```
+
+Expected: both commands PASS.
+
+- [ ] **Step 5: Commit final fixes from verification**
+
+```bash
+git status --short
+```
+
+Expected: empty output. If non-empty output appears after verification commands, stop and add a focused follow-up fix task instead of creating an unscoped commit.

--- a/docs/superpowers/specs/2026-05-03-kt-archive-first-design.md
+++ b/docs/superpowers/specs/2026-05-03-kt-archive-first-design.md
@@ -1,0 +1,148 @@
+# KT Archive-First Page Design
+
+Date: 2026-05-03  
+Status: Draft for review
+
+## 1. Context
+
+The clan dashboard already includes a readiness card for KT and a countdown link target (`/dashboard/clan-wars`), but no dedicated KT page exists yet.
+
+User terminology note:
+
+- `КВ`, `КТ`, `клан варс`, `клан турнир`, `clan wars`, and `clan tournament` are treated as the same activity.
+
+## 2. Goal
+
+Build a dedicated KT page with an **Archive-First** focus: historical clarity over pseudo-live command features.
+
+Primary user value:
+
+- see past KT windows quickly;
+- identify roster stability;
+- detect contribution decline trends.
+
+## 3. Non-Goals
+
+- No live war-room orchestration.
+- No win-probability prediction.
+- No synthetic command-center metrics unsupported by current data.
+- No expanded data ingestion work in this scope.
+
+## 4. Page Information Architecture (`/dashboard/clan-wars`)
+
+1. `KT Timeline Header`
+- countdown to next `start` or current window `reset/end`;
+- personal rewards badge (`с личными наградами` / `без`).
+
+2. `История окон КТ` (primary block)
+- table of latest windows (default 12);
+- columns: window dates, rewards flag, clan total points, active contributors (`points > 0`), top-1 player.
+
+3. `Стабильность состава`
+- player-level archive rollup across selected windows.
+
+4. `Кто проседает`
+- players with negative trend comparing recent windows vs baseline.
+
+## 5. Data Sources And Metrics
+
+Data tables already available:
+
+- `competition_window` (`activity_type='clan_wars'`);
+- `clan_wars_report` (`has_personal_rewards`);
+- `clan_wars_player_score` (`points`, `player_profile_id`);
+- `player_profile` (name/status for display).
+
+### 5.1 Header Metrics
+
+Use existing anchor logic from repository layer (`getClanWarsAnchorStateUtc(nowIso)`):
+
+- `targetAt`;
+- `targetKind` (`start` | `reset`);
+- `hasPersonalRewards`.
+
+### 5.2 KT Windows History Metrics
+
+Per window:
+
+- `windowStart`, `windowEnd`;
+- `hasPersonalRewards`;
+- `clanTotalPoints = SUM(points)`;
+- `activeContributors = COUNT(DISTINCT player_profile_id WHERE points > 0)`;
+- `topPlayer` by max `points` with deterministic tie-break by `player name ASC`.
+
+### 5.3 Roster Stability Metrics
+
+Per player over selected `N` windows:
+
+- `windowsPlayed` (`points > 0`);
+- `avgPoints`;
+- `bestPoints`;
+- `lastWindowPoints`;
+- `consistencyScore = windowsPlayed / N`.
+
+### 5.4 Decline Radar Metrics
+
+For players with at least 3 played windows:
+
+- `recentAvg`: average over latest 3 windows;
+- `baselineAvg`: average over preceding windows (prefer last 6 preceding, else all preceding);
+- `delta = recentAvg - baselineAvg`;
+- descending risk list by most negative `delta`.
+
+## 6. UX Rules (Mobile-First)
+
+Mobile order:
+
+1. header strip;
+2. history table;
+3. roster stability;
+4. decline radar.
+
+Desktop layout:
+
+- top: header + period filter (`12`, `24`, `all`);
+- middle: wide sortable history table;
+- bottom: two-column grid (`Стабильность состава`, `Кто проседает`).
+
+Interaction notes:
+
+- KT readiness card on `/dashboard` remains clickable to `/dashboard/clan-wars`;
+- `DashboardNav` gets a direct `KT` link.
+
+## 7. Rendering and State
+
+- Server renders page snapshot (same pattern as dashboard).
+- Countdown runs on client via existing `CountdownTimer`.
+- History/stability/decline use server-provided snapshot and deterministic sorting defaults.
+- Empty state for no rows: explicit message, never silent blank cards.
+
+## 8. Error Handling
+
+- Invalid or missing countdown target: render neutral fallback (`—`) and log typed warning.
+- Query partial failure: fail-fast response for snapshot endpoint, avoid mixing stale and fresh blocks.
+- Missing personal rewards flag: treat as `0`/`без` by schema default.
+
+## 9. Testing Expectations
+
+Minimum tests for KT page rollout:
+
+1. snapshot query unit tests for history aggregation fields;
+2. stability metric tests (`windowsPlayed`, `consistencyScore`);
+3. decline radar tests (recent vs baseline delta ordering);
+4. page render test covering all four KT blocks and nav link presence;
+5. countdown display test for `start` and `reset` header modes.
+
+## 10. Acceptance Criteria
+
+- Dashboard readiness KT card shows countdown and links to `/dashboard/clan-wars`.
+- Dashboard navigation includes `KT`.
+- KT page renders archive-first structure with real DB-backed metrics.
+- No fabricated command-center blocks are introduced.
+
+## 11. Recommended Delivery Slice
+
+1. Add KT route and server snapshot loader for archive metrics.
+2. Add UI blocks in archive-first order.
+3. Wire nav link and readiness link validation.
+4. Add tests and run baseline repo quality gates.

--- a/packages/application/src/dashboard/get-clan-wars-archive-snapshot.ts
+++ b/packages/application/src/dashboard/get-clan-wars-archive-snapshot.ts
@@ -1,0 +1,31 @@
+import type { ClanWarsArchiveData, ClanWarsArchiveRepository } from "@raid/ports";
+
+export type ClanWarsArchiveSnapshot = ClanWarsArchiveData & { generatedAt: string };
+
+export type GetClanWarsArchiveSnapshotDeps = {
+  repository: ClanWarsArchiveRepository;
+  now?: () => Date;
+  windowLimit?: number;
+};
+
+export const createGetClanWarsArchiveSnapshot = ({
+  repository,
+  now = () => new Date(),
+  windowLimit = 12
+}: GetClanWarsArchiveSnapshotDeps) => {
+  return async (): Promise<ClanWarsArchiveSnapshot> => {
+    const nowIso = now().toISOString();
+    const archive = await repository.getClanWarsArchive({
+      nowIso,
+      windowLimit
+    });
+
+    return {
+      generatedAt: nowIso,
+      header: archive.header,
+      history: archive.history,
+      stability: archive.stability,
+      decline: archive.decline
+    };
+  };
+};

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./telegram/handle-telegram-update";
 export * from "./dashboard/get-clan-dashboard-snapshot";
+export * from "./dashboard/get-clan-wars-archive-snapshot";

--- a/packages/application/test/get-clan-wars-archive-snapshot.test.ts
+++ b/packages/application/test/get-clan-wars-archive-snapshot.test.ts
@@ -1,48 +1,50 @@
 import { describe, expect, it, vi } from "vitest";
 import { createGetClanWarsArchiveSnapshot } from "@raid/application";
-import type { ClanWarsArchiveRepository } from "@raid/ports";
+import type { ClanWarsArchiveData, ClanWarsArchiveRepository } from "@raid/ports";
 
 describe("createGetClanWarsArchiveSnapshot", () => {
   it("calls repository and returns generated archive snapshot", async () => {
+    const archiveData: ClanWarsArchiveData = {
+      header: {
+        targetAt: "2026-05-06T07:00:00.000Z",
+        targetKind: "start",
+        eventStartAt: "2026-05-05T07:00:00.000Z",
+        eventEndsAt: "2026-05-06T07:00:00.000Z",
+        hasPersonalRewards: true
+      },
+      history: [
+        {
+          windowStart: "2026-04-28T07:00:00.000Z",
+          windowEnd: "2026-04-29T07:00:00.000Z",
+          hasPersonalRewards: false,
+          clanTotalPoints: 123_456,
+          activeContributors: 27,
+          topPlayerName: "Morrigan",
+          topPlayerPoints: 12_345
+        }
+      ],
+      stability: [
+        {
+          playerName: "Flemeth",
+          windowsPlayed: 8,
+          avgPoints: 9_000,
+          bestPoints: 13_500,
+          lastWindowPoints: 8_400,
+          consistencyScore: 0.81
+        }
+      ],
+      decline: [
+        {
+          playerName: "Alistair",
+          recentAvg: 1_200,
+          baselineAvg: 2_100,
+          delta: -900
+        }
+      ]
+    };
+
     const repository: ClanWarsArchiveRepository = {
-      getClanWarsArchive: vi.fn(async () => ({
-        header: {
-          targetAt: "2026-05-06T07:00:00.000Z",
-          targetKind: "start",
-          eventStartAt: "2026-05-05T07:00:00.000Z",
-          eventEndsAt: "2026-05-06T07:00:00.000Z",
-          hasPersonalRewards: true
-        },
-        history: [
-          {
-            windowStart: "2026-04-28T07:00:00.000Z",
-            windowEnd: "2026-04-29T07:00:00.000Z",
-            hasPersonalRewards: false,
-            clanTotalPoints: 123_456,
-            activeContributors: 27,
-            topPlayerName: "Morrigan",
-            topPlayerPoints: 12_345
-          }
-        ],
-        stability: [
-          {
-            playerName: "Flemeth",
-            windowsPlayed: 8,
-            avgPoints: 9_000,
-            bestPoints: 13_500,
-            lastWindowPoints: 8_400,
-            consistencyScore: 0.81
-          }
-        ],
-        decline: [
-          {
-            playerName: "Alistair",
-            recentAvg: 1_200,
-            baselineAvg: 2_100,
-            delta: -900
-          }
-        ]
-      }))
+      getClanWarsArchive: vi.fn(async () => archiveData)
     };
 
     const getSnapshot = createGetClanWarsArchiveSnapshot({

--- a/packages/application/test/get-clan-wars-archive-snapshot.test.ts
+++ b/packages/application/test/get-clan-wars-archive-snapshot.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { createGetClanWarsArchiveSnapshot } from "@raid/application";
+import type { ClanWarsArchiveRepository } from "@raid/ports";
+
+describe("createGetClanWarsArchiveSnapshot", () => {
+  it("calls repository and returns generated archive snapshot", async () => {
+    const repository: ClanWarsArchiveRepository = {
+      getClanWarsArchive: vi.fn(async () => ({
+        header: {
+          targetAt: "2026-05-06T07:00:00.000Z",
+          targetKind: "start",
+          eventStartAt: "2026-05-05T07:00:00.000Z",
+          eventEndsAt: "2026-05-06T07:00:00.000Z",
+          hasPersonalRewards: true
+        },
+        history: [
+          {
+            windowStart: "2026-04-28T07:00:00.000Z",
+            windowEnd: "2026-04-29T07:00:00.000Z",
+            hasPersonalRewards: false,
+            clanTotalPoints: 123_456,
+            activeContributors: 27,
+            topPlayerName: "Morrigan",
+            topPlayerPoints: 12_345
+          }
+        ],
+        stability: [
+          {
+            playerName: "Flemeth",
+            windowsPlayed: 8,
+            avgPoints: 9_000,
+            bestPoints: 13_500,
+            lastWindowPoints: 8_400,
+            consistencyScore: 0.81
+          }
+        ],
+        decline: [
+          {
+            playerName: "Alistair",
+            recentAvg: 1_200,
+            baselineAvg: 2_100,
+            delta: -900
+          }
+        ]
+      }))
+    };
+
+    const getSnapshot = createGetClanWarsArchiveSnapshot({
+      repository,
+      now: () => new Date("2026-05-03T12:00:00.000Z"),
+      windowLimit: 9
+    });
+
+    const snapshot = await getSnapshot();
+
+    expect(repository.getClanWarsArchive).toHaveBeenCalledWith({
+      nowIso: "2026-05-03T12:00:00.000Z",
+      windowLimit: 9
+    });
+    expect(snapshot.generatedAt).toBe("2026-05-03T12:00:00.000Z");
+    expect(snapshot.header.targetKind).toBe("start");
+    expect(snapshot.history).toHaveLength(1);
+    expect(snapshot.stability[0]?.playerName).toBe("Flemeth");
+    expect(snapshot.decline[0]?.delta).toBe(-900);
+  });
+});

--- a/packages/platform/src/dashboard/clan-wars-archive-metrics.ts
+++ b/packages/platform/src/dashboard/clan-wars-archive-metrics.ts
@@ -31,7 +31,7 @@ export const buildClanWarsStabilityRows = (
   rows: ClanWarsPlayerWindowPointsRow[],
   selectedWindows: number
 ): ClanWarsArchiveStabilityRow[] => {
-  if (selectedWindows <= 0) {
+  if (!Number.isFinite(selectedWindows) || !Number.isInteger(selectedWindows) || selectedWindows <= 0) {
     return [];
   }
 

--- a/packages/platform/src/dashboard/clan-wars-archive-metrics.ts
+++ b/packages/platform/src/dashboard/clan-wars-archive-metrics.ts
@@ -7,6 +7,8 @@ export type ClanWarsPlayerWindowPointsRow = {
 };
 
 const round2 = (value: number) => Math.round(value * 100) / 100;
+const RECENT_WINDOWS_COUNT = 3;
+const BASELINE_MAX_WINDOWS = 6;
 
 const getSortedWindowsDesc = (rows: ClanWarsPlayerWindowPointsRow[]) =>
   Array.from(new Set(rows.map((row) => row.windowStart))).sort((a, b) =>
@@ -29,6 +31,10 @@ export const buildClanWarsStabilityRows = (
   rows: ClanWarsPlayerWindowPointsRow[],
   selectedWindows: number
 ): ClanWarsArchiveStabilityRow[] => {
+  if (selectedWindows <= 0) {
+    return [];
+  }
+
   const windows = getSortedWindowsDesc(rows).slice(0, selectedWindows);
   const grouped = groupPlayerPoints(rows);
 
@@ -69,12 +75,15 @@ export const buildClanWarsDeclineRows = (
   rows: ClanWarsPlayerWindowPointsRow[]
 ): ClanWarsArchiveDeclineRow[] => {
   const windows = getSortedWindowsDesc(rows);
-  const recentWindows = windows.slice(0, 3);
-  const precedingWindows = windows.slice(3);
-  const baselineWindows = precedingWindows.length > 6 ? precedingWindows.slice(0, 6) : precedingWindows;
+  const recentWindows = windows.slice(0, RECENT_WINDOWS_COUNT);
+  const precedingWindows = windows.slice(RECENT_WINDOWS_COUNT);
+  const baselineWindows =
+    precedingWindows.length > BASELINE_MAX_WINDOWS
+      ? precedingWindows.slice(0, BASELINE_MAX_WINDOWS)
+      : precedingWindows;
   const grouped = groupPlayerPoints(rows);
 
-  if (recentWindows.length < 3 || baselineWindows.length === 0) {
+  if (recentWindows.length < RECENT_WINDOWS_COUNT || baselineWindows.length === 0) {
     return [];
   }
 

--- a/packages/platform/src/dashboard/clan-wars-archive-metrics.ts
+++ b/packages/platform/src/dashboard/clan-wars-archive-metrics.ts
@@ -2,6 +2,7 @@ import type { ClanWarsArchiveDeclineRow, ClanWarsArchiveStabilityRow } from "@ra
 
 export type ClanWarsPlayerWindowPointsRow = {
   windowStart: string;
+  playerId: number;
   playerName: string;
   points: number;
 };
@@ -16,12 +17,16 @@ const getSortedWindowsDesc = (rows: ClanWarsPlayerWindowPointsRow[]) =>
   );
 
 const groupPlayerPoints = (rows: ClanWarsPlayerWindowPointsRow[]) => {
-  const grouped = new Map<string, Map<string, number>>();
+  const grouped = new Map<number, { playerName: string; pointsByWindow: Map<string, number> }>();
 
   for (const row of rows) {
-    const perPlayer = grouped.get(row.playerName) ?? new Map<string, number>();
-    perPlayer.set(row.windowStart, row.points);
-    grouped.set(row.playerName, perPlayer);
+    const existing = grouped.get(row.playerId) ?? {
+      playerName: row.playerName,
+      pointsByWindow: new Map<string, number>()
+    };
+
+    existing.pointsByWindow.set(row.windowStart, row.points);
+    grouped.set(row.playerId, existing);
   }
 
   return grouped;
@@ -39,7 +44,8 @@ export const buildClanWarsStabilityRows = (
   const grouped = groupPlayerPoints(rows);
 
   return Array.from(grouped.entries())
-    .map(([playerName, pointsByWindow]) => {
+    .map(([, player]) => {
+      const { playerName, pointsByWindow } = player;
       const values = windows.map((windowStart) => pointsByWindow.get(windowStart) ?? 0);
       const windowsPlayed = values.filter((points) => points > 0).length;
       const avgPoints =
@@ -88,7 +94,8 @@ export const buildClanWarsDeclineRows = (
   }
 
   return Array.from(grouped.entries())
-    .map(([playerName, pointsByWindow]) => {
+    .map(([, player]) => {
+      const { playerName, pointsByWindow } = player;
       const recentValues = recentWindows.map((windowStart) => pointsByWindow.get(windowStart) ?? 0);
       const baselineValues = baselineWindows.map((windowStart) => pointsByWindow.get(windowStart) ?? 0);
       const windowsPlayed = windows.filter((windowStart) => (pointsByWindow.get(windowStart) ?? 0) > 0).length;

--- a/packages/platform/src/dashboard/clan-wars-archive-metrics.ts
+++ b/packages/platform/src/dashboard/clan-wars-archive-metrics.ts
@@ -1,0 +1,101 @@
+import type { ClanWarsArchiveDeclineRow, ClanWarsArchiveStabilityRow } from "@raid/ports";
+
+export type ClanWarsPlayerWindowPointsRow = {
+  windowStart: string;
+  playerName: string;
+  points: number;
+};
+
+const round2 = (value: number) => Math.round(value * 100) / 100;
+
+const getSortedWindowsDesc = (rows: ClanWarsPlayerWindowPointsRow[]) =>
+  Array.from(new Set(rows.map((row) => row.windowStart))).sort((a, b) =>
+    a < b ? 1 : a > b ? -1 : 0
+  );
+
+const groupPlayerPoints = (rows: ClanWarsPlayerWindowPointsRow[]) => {
+  const grouped = new Map<string, Map<string, number>>();
+
+  for (const row of rows) {
+    const perPlayer = grouped.get(row.playerName) ?? new Map<string, number>();
+    perPlayer.set(row.windowStart, row.points);
+    grouped.set(row.playerName, perPlayer);
+  }
+
+  return grouped;
+};
+
+export const buildClanWarsStabilityRows = (
+  rows: ClanWarsPlayerWindowPointsRow[],
+  selectedWindows: number
+): ClanWarsArchiveStabilityRow[] => {
+  const windows = getSortedWindowsDesc(rows).slice(0, selectedWindows);
+  const grouped = groupPlayerPoints(rows);
+
+  return Array.from(grouped.entries())
+    .map(([playerName, pointsByWindow]) => {
+      const values = windows.map((windowStart) => pointsByWindow.get(windowStart) ?? 0);
+      const windowsPlayed = values.filter((points) => points > 0).length;
+      const avgPoints =
+        values.length === 0 ? 0 : round2(values.reduce((sum, value) => sum + value, 0) / values.length);
+      const bestPoints =
+        values.length === 0
+          ? 0
+          : values.reduce(
+              (maxValue, currentValue) => (currentValue > maxValue ? currentValue : maxValue),
+              values[0]
+            );
+      const lastWindowPoints = values.length === 0 ? 0 : values[0];
+      const consistencyScore = values.length === 0 ? 0 : round2(windowsPlayed / values.length);
+
+      return {
+        playerName,
+        windowsPlayed,
+        avgPoints,
+        bestPoints,
+        lastWindowPoints,
+        consistencyScore
+      };
+    })
+    .sort(
+      (a, b) =>
+        b.consistencyScore - a.consistencyScore ||
+        b.avgPoints - a.avgPoints ||
+        a.playerName.localeCompare(b.playerName)
+    );
+};
+
+export const buildClanWarsDeclineRows = (
+  rows: ClanWarsPlayerWindowPointsRow[]
+): ClanWarsArchiveDeclineRow[] => {
+  const windows = getSortedWindowsDesc(rows);
+  const recentWindows = windows.slice(0, 3);
+  const precedingWindows = windows.slice(3);
+  const baselineWindows = precedingWindows.length > 6 ? precedingWindows.slice(0, 6) : precedingWindows;
+  const grouped = groupPlayerPoints(rows);
+
+  if (recentWindows.length < 3 || baselineWindows.length === 0) {
+    return [];
+  }
+
+  return Array.from(grouped.entries())
+    .map(([playerName, pointsByWindow]) => {
+      const recentValues = recentWindows.map((windowStart) => pointsByWindow.get(windowStart) ?? 0);
+      const baselineValues = baselineWindows.map((windowStart) => pointsByWindow.get(windowStart) ?? 0);
+      const windowsPlayed = windows.filter((windowStart) => (pointsByWindow.get(windowStart) ?? 0) > 0).length;
+
+      if (windowsPlayed < 3) {
+        return null;
+      }
+
+      const recentAvg = round2(recentValues.reduce((sum, value) => sum + value, 0) / recentValues.length);
+      const baselineAvg = round2(
+        baselineValues.reduce((sum, value) => sum + value, 0) / baselineValues.length
+      );
+      const delta = round2(recentAvg - baselineAvg);
+
+      return { playerName, recentAvg, baselineAvg, delta };
+    })
+    .filter((row): row is ClanWarsArchiveDeclineRow => row !== null && row.delta < 0)
+    .sort((a, b) => a.delta - b.delta || a.playerName.localeCompare(b.playerName));
+};

--- a/packages/platform/src/dashboard/clan-wars-archive-sql.ts
+++ b/packages/platform/src/dashboard/clan-wars-archive-sql.ts
@@ -1,0 +1,60 @@
+export const selectClanWarsArchiveHistorySql = `
+WITH recent_windows AS (
+  SELECT id, starts_at, ends_at
+  FROM competition_window
+  WHERE activity_type = 'clan_wars'
+  ORDER BY starts_at DESC, id DESC
+  LIMIT ?
+)
+SELECT
+  rw.starts_at,
+  rw.ends_at,
+  COALESCE(cwr.has_personal_rewards, 0) AS has_personal_rewards,
+  COALESCE(SUM(cwps.points), 0) AS clan_total_points,
+  COALESCE(COUNT(DISTINCT CASE WHEN cwps.points > 0 THEN cwps.player_profile_id END), 0) AS active_contributors,
+  COALESCE((
+    SELECT pp2.main_nickname
+    FROM clan_wars_player_score cwps2
+    JOIN player_profile pp2 ON pp2.id = cwps2.player_profile_id
+    WHERE cwps2.competition_window_id = rw.id
+    ORDER BY cwps2.points DESC, pp2.main_nickname ASC
+    LIMIT 1
+  ), '-') AS top_player_name,
+  COALESCE((
+    SELECT cwps2.points
+    FROM clan_wars_player_score cwps2
+    JOIN player_profile pp2 ON pp2.id = cwps2.player_profile_id
+    WHERE cwps2.competition_window_id = rw.id
+    ORDER BY cwps2.points DESC, pp2.main_nickname ASC
+    LIMIT 1
+  ), 0) AS top_player_points
+FROM recent_windows rw
+LEFT JOIN clan_wars_report cwr ON cwr.competition_window_id = rw.id
+LEFT JOIN clan_wars_player_score cwps ON cwps.competition_window_id = rw.id
+GROUP BY rw.id, rw.starts_at, rw.ends_at, cwr.has_personal_rewards
+ORDER BY rw.starts_at DESC, rw.id DESC;
+`;
+
+export const selectClanWarsArchivePlayerWindowSql = `
+WITH recent_windows AS (
+  SELECT id, starts_at
+  FROM competition_window
+  WHERE activity_type = 'clan_wars'
+  ORDER BY starts_at DESC, id DESC
+  LIMIT ?
+), active_players AS (
+  SELECT id, main_nickname
+  FROM player_profile
+  WHERE status = 'active'
+)
+SELECT
+  rw.starts_at AS window_start,
+  ap.main_nickname AS player_name,
+  COALESCE(cwps.points, 0) AS points
+FROM recent_windows rw
+CROSS JOIN active_players ap
+LEFT JOIN clan_wars_player_score cwps
+  ON cwps.competition_window_id = rw.id
+  AND cwps.player_profile_id = ap.id
+ORDER BY rw.starts_at DESC, ap.main_nickname ASC;
+`;

--- a/packages/platform/src/dashboard/clan-wars-archive-sql.ts
+++ b/packages/platform/src/dashboard/clan-wars-archive-sql.ts
@@ -1,48 +1,71 @@
 export const selectClanWarsArchiveHistorySql = `
 WITH recent_windows AS (
-  SELECT id, starts_at, ends_at
-  FROM competition_window
-  WHERE activity_type = 'clan_wars'
-  ORDER BY starts_at DESC, id DESC
+  SELECT
+    cw.id,
+    cw.starts_at,
+    cw.ends_at,
+    cwr.id AS report_id,
+    cwr.has_personal_rewards
+  FROM competition_window cw
+  JOIN clan_wars_report cwr
+    ON cwr.id = (
+      SELECT cwr2.id
+      FROM clan_wars_report cwr2
+      WHERE cwr2.competition_window_id = cw.id
+      ORDER BY cwr2.created_at DESC, cwr2.id DESC
+      LIMIT 1
+    )
+  WHERE cw.activity_type = 'clan_wars'
+    AND cw.starts_at <= ?
+  ORDER BY cw.starts_at DESC, cw.id DESC
   LIMIT ?
 )
 SELECT
   rw.starts_at,
   rw.ends_at,
-  COALESCE(cwr.has_personal_rewards, 0) AS has_personal_rewards,
+  rw.has_personal_rewards AS has_personal_rewards,
   COALESCE(SUM(cwps.points), 0) AS clan_total_points,
   COALESCE(COUNT(DISTINCT CASE WHEN cwps.points > 0 THEN cwps.player_profile_id END), 0) AS active_contributors,
   COALESCE((
-    SELECT pp2.main_nickname
-    FROM clan_wars_report cwr2
-    JOIN clan_wars_player_score cwps2 ON cwps2.clan_wars_report_id = cwr2.id
-    JOIN player_profile pp2 ON pp2.id = cwps2.player_profile_id
-    WHERE cwr2.competition_window_id = rw.id
-    ORDER BY cwps2.points DESC, pp2.main_nickname ASC
+    SELECT pp.main_nickname
+    FROM clan_wars_player_score cwps2
+    JOIN player_profile pp ON pp.id = cwps2.player_profile_id
+    WHERE cwps2.clan_wars_report_id = rw.report_id
+    ORDER BY cwps2.points DESC, pp.main_nickname ASC
     LIMIT 1
   ), '-') AS top_player_name,
   COALESCE((
     SELECT cwps2.points
-    FROM clan_wars_report cwr2
-    JOIN clan_wars_player_score cwps2 ON cwps2.clan_wars_report_id = cwr2.id
-    JOIN player_profile pp2 ON pp2.id = cwps2.player_profile_id
-    WHERE cwr2.competition_window_id = rw.id
-    ORDER BY cwps2.points DESC, pp2.main_nickname ASC
+    FROM clan_wars_player_score cwps2
+    JOIN player_profile pp ON pp.id = cwps2.player_profile_id
+    WHERE cwps2.clan_wars_report_id = rw.report_id
+    ORDER BY cwps2.points DESC, pp.main_nickname ASC
     LIMIT 1
   ), 0) AS top_player_points
 FROM recent_windows rw
-LEFT JOIN clan_wars_report cwr ON cwr.competition_window_id = rw.id
-LEFT JOIN clan_wars_player_score cwps ON cwps.clan_wars_report_id = cwr.id
-GROUP BY rw.id, rw.starts_at, rw.ends_at, cwr.has_personal_rewards
+LEFT JOIN clan_wars_player_score cwps ON cwps.clan_wars_report_id = rw.report_id
+GROUP BY rw.id, rw.starts_at, rw.ends_at, rw.has_personal_rewards, rw.report_id
 ORDER BY rw.starts_at DESC, rw.id DESC;
 `;
 
 export const selectClanWarsArchivePlayerWindowSql = `
 WITH recent_windows AS (
-  SELECT id, starts_at
-  FROM competition_window
-  WHERE activity_type = 'clan_wars'
-  ORDER BY starts_at DESC, id DESC
+  SELECT
+    cw.id,
+    cw.starts_at,
+    cwr.id AS report_id
+  FROM competition_window cw
+  JOIN clan_wars_report cwr
+    ON cwr.id = (
+      SELECT cwr2.id
+      FROM clan_wars_report cwr2
+      WHERE cwr2.competition_window_id = cw.id
+      ORDER BY cwr2.created_at DESC, cwr2.id DESC
+      LIMIT 1
+    )
+  WHERE cw.activity_type = 'clan_wars'
+    AND cw.starts_at <= ?
+  ORDER BY cw.starts_at DESC, cw.id DESC
   LIMIT ?
 ), active_players AS (
   SELECT id, main_nickname
@@ -51,13 +74,13 @@ WITH recent_windows AS (
 )
 SELECT
   rw.starts_at AS window_start,
+  ap.id AS player_id,
   ap.main_nickname AS player_name,
   COALESCE(cwps.points, 0) AS points
 FROM recent_windows rw
 CROSS JOIN active_players ap
-LEFT JOIN clan_wars_report cwr ON cwr.competition_window_id = rw.id
 LEFT JOIN clan_wars_player_score cwps
-  ON cwps.clan_wars_report_id = cwr.id
+  ON cwps.clan_wars_report_id = rw.report_id
   AND cwps.player_profile_id = ap.id
 ORDER BY rw.starts_at DESC, ap.main_nickname ASC;
 `;

--- a/packages/platform/src/dashboard/clan-wars-archive-sql.ts
+++ b/packages/platform/src/dashboard/clan-wars-archive-sql.ts
@@ -14,23 +14,25 @@ SELECT
   COALESCE(COUNT(DISTINCT CASE WHEN cwps.points > 0 THEN cwps.player_profile_id END), 0) AS active_contributors,
   COALESCE((
     SELECT pp2.main_nickname
-    FROM clan_wars_player_score cwps2
+    FROM clan_wars_report cwr2
+    JOIN clan_wars_player_score cwps2 ON cwps2.clan_wars_report_id = cwr2.id
     JOIN player_profile pp2 ON pp2.id = cwps2.player_profile_id
-    WHERE cwps2.competition_window_id = rw.id
+    WHERE cwr2.competition_window_id = rw.id
     ORDER BY cwps2.points DESC, pp2.main_nickname ASC
     LIMIT 1
   ), '-') AS top_player_name,
   COALESCE((
     SELECT cwps2.points
-    FROM clan_wars_player_score cwps2
+    FROM clan_wars_report cwr2
+    JOIN clan_wars_player_score cwps2 ON cwps2.clan_wars_report_id = cwr2.id
     JOIN player_profile pp2 ON pp2.id = cwps2.player_profile_id
-    WHERE cwps2.competition_window_id = rw.id
+    WHERE cwr2.competition_window_id = rw.id
     ORDER BY cwps2.points DESC, pp2.main_nickname ASC
     LIMIT 1
   ), 0) AS top_player_points
 FROM recent_windows rw
 LEFT JOIN clan_wars_report cwr ON cwr.competition_window_id = rw.id
-LEFT JOIN clan_wars_player_score cwps ON cwps.competition_window_id = rw.id
+LEFT JOIN clan_wars_player_score cwps ON cwps.clan_wars_report_id = cwr.id
 GROUP BY rw.id, rw.starts_at, rw.ends_at, cwr.has_personal_rewards
 ORDER BY rw.starts_at DESC, rw.id DESC;
 `;
@@ -53,8 +55,9 @@ SELECT
   COALESCE(cwps.points, 0) AS points
 FROM recent_windows rw
 CROSS JOIN active_players ap
+LEFT JOIN clan_wars_report cwr ON cwr.competition_window_id = rw.id
 LEFT JOIN clan_wars_player_score cwps
-  ON cwps.competition_window_id = rw.id
+  ON cwps.clan_wars_report_id = cwr.id
   AND cwps.player_profile_id = ap.id
 ORDER BY rw.starts_at DESC, ap.main_nickname ASC;
 `;

--- a/packages/platform/src/dashboard/clan-wars-archive-sql.ts
+++ b/packages/platform/src/dashboard/clan-wars-archive-sql.ts
@@ -16,7 +16,7 @@ WITH recent_windows AS (
       LIMIT 1
     )
   WHERE cw.activity_type = 'clan_wars'
-    AND cw.starts_at <= ?
+    AND cw.ends_at <= ?
   ORDER BY cw.starts_at DESC, cw.id DESC
   LIMIT ?
 )
@@ -64,7 +64,7 @@ WITH recent_windows AS (
       LIMIT 1
     )
   WHERE cw.activity_type = 'clan_wars'
-    AND cw.starts_at <= ?
+    AND cw.ends_at <= ?
   ORDER BY cw.starts_at DESC, cw.id DESC
   LIMIT ?
 ), active_players AS (
@@ -82,5 +82,5 @@ CROSS JOIN active_players ap
 LEFT JOIN clan_wars_player_score cwps
   ON cwps.clan_wars_report_id = rw.report_id
   AND cwps.player_profile_id = ap.id
-ORDER BY rw.starts_at DESC, ap.main_nickname ASC;
+ORDER BY rw.starts_at DESC, ap.main_nickname ASC, ap.id ASC;
 `;

--- a/packages/platform/src/dashboard/create-d1-clan-dashboard-repository.ts
+++ b/packages/platform/src/dashboard/create-d1-clan-dashboard-repository.ts
@@ -69,6 +69,7 @@ type ClanWarsArchiveHistoryDbRow = {
 
 type ClanWarsArchivePlayerWindowDbRow = {
   window_start: string;
+  player_id: number;
   player_name: string;
   points: number;
 };
@@ -218,9 +219,10 @@ export const createD1ClanDashboardRepository = (
     },
     async getClanWarsArchive({ nowIso, windowLimit }): Promise<ClanWarsArchiveData> {
       const [historyRows, playerWindowRows] = await Promise.all([
-        queryRows<ClanWarsArchiveHistoryDbRow>(selectClanWarsArchiveHistorySql, windowLimit),
+        queryRows<ClanWarsArchiveHistoryDbRow>(selectClanWarsArchiveHistorySql, nowIso, windowLimit),
         queryRows<ClanWarsArchivePlayerWindowDbRow>(
           selectClanWarsArchivePlayerWindowSql,
+          nowIso,
           windowLimit
         )
       ]);
@@ -228,6 +230,7 @@ export const createD1ClanDashboardRepository = (
       const clanWarsAnchor = getClanWarsAnchorStateUtc(nowIso);
       const playerRows: ClanWarsPlayerWindowPointsRow[] = playerWindowRows.map((row) => ({
         windowStart: row.window_start,
+        playerId: row.player_id,
         playerName: row.player_name,
         points: asNumber(row.points)
       }));

--- a/packages/platform/src/dashboard/create-d1-clan-dashboard-repository.ts
+++ b/packages/platform/src/dashboard/create-d1-clan-dashboard-repository.ts
@@ -1,11 +1,22 @@
 import type {
   ClanDashboardData,
   ClanDashboardRepository,
+  ClanWarsArchiveData,
+  ClanWarsArchiveRepository,
   DashboardRankingRow,
   DashboardReadinessCard,
   DashboardTrendPoint,
   DashboardTopBottom
 } from "@raid/ports";
+import {
+  buildClanWarsDeclineRows,
+  buildClanWarsStabilityRows,
+  type ClanWarsPlayerWindowPointsRow
+} from "./clan-wars-archive-metrics";
+import {
+  selectClanWarsArchiveHistorySql,
+  selectClanWarsArchivePlayerWindowSql
+} from "./clan-wars-archive-sql";
 import {
   selectChimeraRankingSql,
   selectChimeraReadinessSql,
@@ -44,6 +55,22 @@ type RankingRow = {
 type TrendRow = {
   ends_at: string;
   total_score: number;
+};
+
+type ClanWarsArchiveHistoryDbRow = {
+  starts_at: string;
+  ends_at: string;
+  has_personal_rewards: number;
+  clan_total_points: number;
+  active_contributors: number;
+  top_player_name: string;
+  top_player_points: number;
+};
+
+type ClanWarsArchivePlayerWindowDbRow = {
+  window_start: string;
+  player_name: string;
+  points: number;
 };
 
 const mapRankingRows = (rows: RankingRow[]): DashboardRankingRow[] =>
@@ -88,7 +115,7 @@ const toTrend = (rows: TrendRow[]): DashboardTrendPoint[] =>
 
 export const createD1ClanDashboardRepository = (
   db: D1DatabaseLike
-): ClanDashboardRepository => {
+): ClanDashboardRepository & ClanWarsArchiveRepository => {
   const queryRows = async <T>(sql: string, ...bindValues: unknown[]) => {
     const prepared = db.prepare(sql).bind(...bindValues);
     const result = await prepared.all<T>();
@@ -187,6 +214,43 @@ export const createD1ClanDashboardRepository = (
           hydra: toTrend(hydraTrendRows),
           chimera: toTrend(chimeraTrendRows)
         }
+      };
+    },
+    async getClanWarsArchive({ nowIso, windowLimit }): Promise<ClanWarsArchiveData> {
+      const [historyRows, playerWindowRows] = await Promise.all([
+        queryRows<ClanWarsArchiveHistoryDbRow>(selectClanWarsArchiveHistorySql, windowLimit),
+        queryRows<ClanWarsArchivePlayerWindowDbRow>(
+          selectClanWarsArchivePlayerWindowSql,
+          windowLimit
+        )
+      ]);
+
+      const clanWarsAnchor = getClanWarsAnchorStateUtc(nowIso);
+      const playerRows: ClanWarsPlayerWindowPointsRow[] = playerWindowRows.map((row) => ({
+        windowStart: row.window_start,
+        playerName: row.player_name,
+        points: asNumber(row.points)
+      }));
+
+      return {
+        header: {
+          targetAt: clanWarsAnchor.targetAt,
+          targetKind: clanWarsAnchor.targetKind,
+          eventStartAt: clanWarsAnchor.eventStartAt,
+          eventEndsAt: clanWarsAnchor.eventEndsAt,
+          hasPersonalRewards: clanWarsAnchor.hasPersonalRewards
+        },
+        history: historyRows.map((row) => ({
+          windowStart: row.starts_at,
+          windowEnd: row.ends_at,
+          hasPersonalRewards: row.has_personal_rewards === 1,
+          clanTotalPoints: asNumber(row.clan_total_points),
+          activeContributors: asNumber(row.active_contributors),
+          topPlayerName: row.top_player_name ?? "-",
+          topPlayerPoints: asNumber(row.top_player_points)
+        })),
+        stability: buildClanWarsStabilityRows(playerRows, windowLimit),
+        decline: buildClanWarsDeclineRows(playerRows)
       };
     }
   };

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./telegram/normalize-update";
 export * from "./telegram/send-telegram-message";
 export * from "./dashboard/clan-dashboard-sql";
+export * from "./dashboard/clan-wars-archive-metrics";
 export * from "./dashboard/create-d1-clan-dashboard-repository";
 export * from "./dashboard/reset-anchors";

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -2,5 +2,6 @@ export * from "./telegram/normalize-update";
 export * from "./telegram/send-telegram-message";
 export * from "./dashboard/clan-dashboard-sql";
 export * from "./dashboard/clan-wars-archive-metrics";
+export * from "./dashboard/clan-wars-archive-sql";
 export * from "./dashboard/create-d1-clan-dashboard-repository";
 export * from "./dashboard/reset-anchors";

--- a/packages/platform/test/clan-dashboard-repository.test.ts
+++ b/packages/platform/test/clan-dashboard-repository.test.ts
@@ -228,6 +228,7 @@ describe("clan dashboard SQL", () => {
       ok: boolean;
       rows: Array<{
         starts_at: string;
+        ends_at: string;
         has_personal_rewards: number;
         clan_total_points: number;
         active_contributors: number;
@@ -239,6 +240,7 @@ describe("clan dashboard SQL", () => {
     expect(result.ok).toBe(true);
     expect(result.rows[0]).toEqual({
       starts_at: "2031-04-12T00:00:00Z",
+      ends_at: "2031-04-14T00:00:00Z",
       has_personal_rewards: 1,
       clan_total_points: 430,
       active_contributors: 3,

--- a/packages/platform/test/clan-dashboard-repository.test.ts
+++ b/packages/platform/test/clan-dashboard-repository.test.ts
@@ -53,4 +53,28 @@ describe("clan dashboard SQL", () => {
     expect(result.row.ends_at).toBe("2031-03-17T00:00:00Z");
     expect(result.row.has_personal_rewards).toBe(0);
   });
+
+  it("aggregates KT archive history for the latest windows", () => {
+    const result = runCheck<{
+      ok: boolean;
+      rows: Array<{
+        starts_at: string;
+        has_personal_rewards: number;
+        clan_total_points: number;
+        active_contributors: number;
+        top_player_name: string;
+        top_player_points: number;
+      }>;
+    }>("kt-archive-history-aggregate");
+
+    expect(result.ok).toBe(true);
+    expect(result.rows[0]).toEqual({
+      starts_at: "2031-04-12T00:00:00Z",
+      has_personal_rewards: 1,
+      clan_total_points: 430,
+      active_contributors: 3,
+      top_player_name: "Alpha",
+      top_player_points: 220
+    });
+  });
 });

--- a/packages/platform/test/clan-dashboard-repository.test.ts
+++ b/packages/platform/test/clan-dashboard-repository.test.ts
@@ -1,6 +1,175 @@
 import { execFileSync } from "node:child_process";
-import { resolve } from "node:path";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+import { createD1ClanDashboardRepository } from "../src/dashboard/create-d1-clan-dashboard-repository";
+
+type D1QueryResult<T> = { results?: T[] };
+type D1PreparedStatementLike = {
+  bind(...values: unknown[]): D1PreparedStatementLike;
+  all<T>(): Promise<D1QueryResult<T>>;
+};
+type D1DatabaseLike = { prepare(query: string): D1PreparedStatementLike };
+type SqliteStatement = {
+  run(...values: unknown[]): { lastInsertRowid: number | bigint };
+  all(...values: unknown[]): unknown[];
+};
+type SqliteDatabase = {
+  exec(sql: string): void;
+  prepare(sql: string): SqliteStatement;
+};
+
+type CompetitionWindowInput = {
+  activityType: "clan_wars";
+  seasonYear: number;
+  week: number;
+  startsAt: string;
+  endsAt: string;
+  label: string;
+};
+
+const applyDashboardMigrations = (database: SqliteDatabase) => {
+  for (const fileName of [
+    "0001_bootstrap.sql",
+    "0002_clan_competition_schema.sql",
+    "0004_clan_wars_has_personal_rewards.sql"
+  ]) {
+    database.exec(readFileSync(join(process.cwd(), "platform", "migrations", fileName), "utf8"));
+  }
+};
+
+const createD1SqliteAdapter = () => {
+  const require = createRequire(import.meta.url);
+  const { DatabaseSync } = require("node:sqlite") as {
+    DatabaseSync: new (path: string) => SqliteDatabase;
+  };
+  const sqlite = new DatabaseSync(":memory:");
+  applyDashboardMigrations(sqlite);
+
+  const d1: D1DatabaseLike = {
+    prepare(query: string) {
+      const statement = sqlite.prepare(query);
+      let bindValues: unknown[] = [];
+
+      const prepared: D1PreparedStatementLike = {
+        bind(...values: unknown[]) {
+          bindValues = values;
+          return prepared;
+        },
+        async all<T>() {
+          const rows = statement.all(...bindValues) as T[];
+          return { results: rows };
+        }
+      };
+
+      return prepared;
+    }
+  };
+
+  return { sqlite, d1 };
+};
+
+const insertReportImport = (database: SqliteDatabase, scopeKey: string) =>
+  Number(
+    database
+      .prepare(
+        [
+          "INSERT INTO report_import",
+          "(upload_type, source_kind, scope_type, scope_key, replace_existing, status)",
+          "VALUES (?, ?, ?, ?, ?, ?)"
+        ].join(" ")
+      )
+      .run("manual_json", "unit_test", "competition_window", scopeKey, 1, "applied")
+      .lastInsertRowid
+  );
+
+const insertCompetitionWindow = (database: SqliteDatabase, input: CompetitionWindowInput) =>
+  Number(
+    database
+      .prepare(
+        [
+          "INSERT INTO competition_window",
+          "(activity_type, season_year, week_of_year, cadence_slot, rotation_number, starts_at, ends_at, label)",
+          "VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+        ].join(" ")
+      )
+      .run(
+        input.activityType,
+        input.seasonYear,
+        input.week,
+        "biweekly",
+        null,
+        input.startsAt,
+        input.endsAt,
+        input.label
+      ).lastInsertRowid
+  );
+
+const insertPlayer = (database: SqliteDatabase, nickname: string, status = "active") =>
+  Number(
+    database
+      .prepare("INSERT INTO player_profile (main_nickname, status) VALUES (?, ?)")
+      .run(nickname, status).lastInsertRowid
+  );
+
+const insertClanWarsReport = (
+  database: SqliteDatabase,
+  input: {
+    windowId: number;
+    scopeKey: string;
+    hasPersonalRewards: number;
+    createdAt: string;
+  }
+) => {
+  const reportImportId = insertReportImport(database, input.scopeKey);
+
+  return Number(
+    database
+      .prepare(
+        [
+          "INSERT INTO clan_wars_report",
+          "(competition_window_id, report_import_id, source_system, is_partial, has_personal_rewards, created_at)",
+          "VALUES (?, ?, ?, ?, ?, ?)"
+        ].join(" ")
+      )
+      .run(
+        input.windowId,
+        reportImportId,
+        "unit",
+        0,
+        input.hasPersonalRewards,
+        input.createdAt
+      ).lastInsertRowid
+  );
+};
+
+const insertClanWarsScore = (
+  database: SqliteDatabase,
+  input: {
+    reportId: number;
+    competitionWindowId: number;
+    playerId: number;
+    displayName: string;
+    points: number;
+  }
+) => {
+  database
+    .prepare(
+      [
+        "INSERT INTO clan_wars_player_score",
+        "(clan_wars_report_id, competition_window_id, player_profile_id, display_name_at_import, points)",
+        "VALUES (?, ?, ?, ?, ?)"
+      ].join(" ")
+    )
+    .run(
+      input.reportId,
+      input.competitionWindowId,
+      input.playerId,
+      input.displayName,
+      input.points
+    );
+};
 
 const helperPath = resolve(
   process.cwd(),
@@ -75,6 +244,167 @@ describe("clan dashboard SQL", () => {
       active_contributors: 3,
       top_player_name: "Alpha",
       top_player_points: 220
+    });
+  });
+
+  it("maps getClanWarsArchive from D1 repository using report-linked score joins", async () => {
+    const { sqlite, d1 } = createD1SqliteAdapter();
+    const alpha = insertPlayer(sqlite, "Alpha");
+    const beta = insertPlayer(sqlite, "Beta");
+    const gamma = insertPlayer(sqlite, "Gamma");
+
+    const window1 = insertCompetitionWindow(sqlite, {
+      activityType: "clan_wars",
+      seasonYear: 2031,
+      week: 9,
+      startsAt: "2031-03-01T00:00:00Z",
+      endsAt: "2031-03-03T00:00:00Z",
+      label: "cw-1"
+    });
+    const window2 = insertCompetitionWindow(sqlite, {
+      activityType: "clan_wars",
+      seasonYear: 2031,
+      week: 10,
+      startsAt: "2031-03-15T00:00:00Z",
+      endsAt: "2031-03-17T00:00:00Z",
+      label: "cw-2"
+    });
+    const window3 = insertCompetitionWindow(sqlite, {
+      activityType: "clan_wars",
+      seasonYear: 2031,
+      week: 11,
+      startsAt: "2031-03-29T00:00:00Z",
+      endsAt: "2031-03-31T00:00:00Z",
+      label: "cw-3"
+    });
+    const window4 = insertCompetitionWindow(sqlite, {
+      activityType: "clan_wars",
+      seasonYear: 2031,
+      week: 12,
+      startsAt: "2031-04-12T00:00:00Z",
+      endsAt: "2031-04-14T00:00:00Z",
+      label: "cw-4"
+    });
+
+    const report1 = insertClanWarsReport(sqlite, {
+      windowId: window1,
+      scopeKey: "cw-1",
+      hasPersonalRewards: 0,
+      createdAt: "2031-03-01T01:00:00Z"
+    });
+    const report2 = insertClanWarsReport(sqlite, {
+      windowId: window2,
+      scopeKey: "cw-2",
+      hasPersonalRewards: 0,
+      createdAt: "2031-03-15T01:00:00Z"
+    });
+    const report3 = insertClanWarsReport(sqlite, {
+      windowId: window3,
+      scopeKey: "cw-3",
+      hasPersonalRewards: 0,
+      createdAt: "2031-03-29T01:00:00Z"
+    });
+    const report4 = insertClanWarsReport(sqlite, {
+      windowId: window4,
+      scopeKey: "cw-4",
+      hasPersonalRewards: 1,
+      createdAt: "2031-04-12T01:00:00Z"
+    });
+
+    insertClanWarsScore(sqlite, {
+      reportId: report1,
+      competitionWindowId: window1,
+      playerId: alpha,
+      displayName: "Alpha",
+      points: 300
+    });
+    insertClanWarsScore(sqlite, {
+      reportId: report1,
+      competitionWindowId: window1,
+      playerId: beta,
+      displayName: "Beta",
+      points: 50
+    });
+    insertClanWarsScore(sqlite, {
+      reportId: report2,
+      competitionWindowId: window2,
+      playerId: alpha,
+      displayName: "Alpha",
+      points: 80
+    });
+    insertClanWarsScore(sqlite, {
+      reportId: report2,
+      competitionWindowId: window2,
+      playerId: beta,
+      displayName: "Beta",
+      points: 60
+    });
+    insertClanWarsScore(sqlite, {
+      reportId: report3,
+      competitionWindowId: window3,
+      playerId: alpha,
+      displayName: "Alpha",
+      points: 90
+    });
+    insertClanWarsScore(sqlite, {
+      reportId: report3,
+      competitionWindowId: window3,
+      playerId: beta,
+      displayName: "Beta",
+      points: 70
+    });
+    insertClanWarsScore(sqlite, {
+      reportId: report4,
+      competitionWindowId: window4,
+      playerId: alpha,
+      displayName: "Alpha",
+      points: 100
+    });
+    insertClanWarsScore(sqlite, {
+      reportId: report4,
+      competitionWindowId: window1,
+      playerId: beta,
+      displayName: "Beta",
+      points: 80
+    });
+    insertClanWarsScore(sqlite, {
+      reportId: report4,
+      competitionWindowId: window4,
+      playerId: gamma,
+      displayName: "Gamma",
+      points: 20
+    });
+
+    const repository = createD1ClanDashboardRepository(d1);
+    const archive = await repository.getClanWarsArchive({
+      nowIso: "2026-05-03T11:22:00.000Z",
+      windowLimit: 12
+    });
+
+    expect(archive.history[0]).toEqual({
+      windowStart: "2031-04-12T00:00:00Z",
+      windowEnd: "2031-04-14T00:00:00Z",
+      hasPersonalRewards: true,
+      clanTotalPoints: 200,
+      activeContributors: 3,
+      topPlayerName: "Alpha",
+      topPlayerPoints: 100
+    });
+
+    const oldestWindow = archive.history.find(
+      (row) => row.windowStart === "2031-03-01T00:00:00Z"
+    );
+
+    expect(oldestWindow?.clanTotalPoints).toBe(350);
+    expect(archive.stability.length).toBeGreaterThan(0);
+    expect(archive.stability.some((row) => row.playerName === "Alpha")).toBe(true);
+
+    const alphaDecline = archive.decline.find((row) => row.playerName === "Alpha");
+    expect(alphaDecline).toEqual({
+      playerName: "Alpha",
+      recentAvg: 90,
+      baselineAvg: 300,
+      delta: -210
     });
   });
 });

--- a/packages/platform/test/clan-dashboard-repository.test.ts
+++ b/packages/platform/test/clan-dashboard-repository.test.ts
@@ -377,7 +377,7 @@ describe("clan dashboard SQL", () => {
 
     const repository = createD1ClanDashboardRepository(d1);
     const archive = await repository.getClanWarsArchive({
-      nowIso: "2026-05-03T11:22:00.000Z",
+      nowIso: "2031-05-03T11:22:00.000Z",
       windowLimit: 12
     });
 

--- a/packages/platform/test/clan-dashboard-repository.test.ts
+++ b/packages/platform/test/clan-dashboard-repository.test.ts
@@ -287,6 +287,14 @@ describe("clan dashboard SQL", () => {
       endsAt: "2031-04-14T00:00:00Z",
       label: "cw-4"
     });
+    const window5InProgress = insertCompetitionWindow(sqlite, {
+      activityType: "clan_wars",
+      seasonYear: 2031,
+      week: 13,
+      startsAt: "2031-05-01T00:00:00Z",
+      endsAt: "2031-05-15T00:00:00Z",
+      label: "cw-5-in-progress"
+    });
 
     const report1 = insertClanWarsReport(sqlite, {
       windowId: window1,
@@ -311,6 +319,12 @@ describe("clan dashboard SQL", () => {
       scopeKey: "cw-4",
       hasPersonalRewards: 1,
       createdAt: "2031-04-12T01:00:00Z"
+    });
+    const report5InProgress = insertClanWarsReport(sqlite, {
+      windowId: window5InProgress,
+      scopeKey: "cw-5",
+      hasPersonalRewards: 1,
+      createdAt: "2031-05-01T01:00:00Z"
     });
 
     insertClanWarsScore(sqlite, {
@@ -376,6 +390,13 @@ describe("clan dashboard SQL", () => {
       displayName: "Gamma",
       points: 20
     });
+    insertClanWarsScore(sqlite, {
+      reportId: report5InProgress,
+      competitionWindowId: window5InProgress,
+      playerId: alpha,
+      displayName: "Alpha",
+      points: 999
+    });
 
     const repository = createD1ClanDashboardRepository(d1);
     const archive = await repository.getClanWarsArchive({
@@ -396,8 +417,12 @@ describe("clan dashboard SQL", () => {
     const oldestWindow = archive.history.find(
       (row) => row.windowStart === "2031-03-01T00:00:00Z"
     );
+    const inProgressWindow = archive.history.find(
+      (row) => row.windowStart === "2031-05-01T00:00:00Z"
+    );
 
     expect(oldestWindow?.clanTotalPoints).toBe(350);
+    expect(inProgressWindow).toBeUndefined();
     expect(archive.stability.length).toBeGreaterThan(0);
     expect(archive.stability.some((row) => row.playerName === "Alpha")).toBe(true);
 

--- a/packages/platform/test/clan-wars-archive-metrics.test.ts
+++ b/packages/platform/test/clan-wars-archive-metrics.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildClanWarsDeclineRows,
+  buildClanWarsStabilityRows,
+  type ClanWarsPlayerWindowPointsRow
+} from "@raid/platform";
+
+const rows: ClanWarsPlayerWindowPointsRow[] = [
+  { windowStart: "2031-04-07T10:00:00.000Z", playerName: "Alpha", points: 210 },
+  { windowStart: "2031-04-07T10:00:00.000Z", playerName: "Beta", points: 40 },
+  { windowStart: "2031-04-07T10:00:00.000Z", playerName: "Gamma", points: 100 },
+  { windowStart: "2031-03-24T10:00:00.000Z", playerName: "Alpha", points: 240 },
+  { windowStart: "2031-03-24T10:00:00.000Z", playerName: "Beta", points: 60 },
+  { windowStart: "2031-03-24T10:00:00.000Z", playerName: "Gamma", points: 90 },
+  { windowStart: "2031-03-10T10:00:00.000Z", playerName: "Alpha", points: 260 },
+  { windowStart: "2031-03-10T10:00:00.000Z", playerName: "Beta", points: 90 },
+  { windowStart: "2031-03-10T10:00:00.000Z", playerName: "Gamma", points: 80 },
+  { windowStart: "2031-02-24T10:00:00.000Z", playerName: "Alpha", points: 280 },
+  { windowStart: "2031-02-24T10:00:00.000Z", playerName: "Beta", points: 120 },
+  { windowStart: "2031-02-24T10:00:00.000Z", playerName: "Gamma", points: 70 },
+  { windowStart: "2031-02-10T10:00:00.000Z", playerName: "Alpha", points: 300 },
+  { windowStart: "2031-02-10T10:00:00.000Z", playerName: "Beta", points: 140 },
+  { windowStart: "2031-02-10T10:00:00.000Z", playerName: "Gamma", points: 60 },
+  { windowStart: "2031-01-27T10:00:00.000Z", playerName: "Alpha", points: 320 },
+  { windowStart: "2031-01-27T10:00:00.000Z", playerName: "Beta", points: 160 },
+  { windowStart: "2031-01-27T10:00:00.000Z", playerName: "Gamma", points: 50 }
+];
+
+describe("KT archive metrics", () => {
+  it("computes stability rows from player-window matrix", () => {
+    const stability = buildClanWarsStabilityRows(rows, 6);
+
+    expect(stability[0]).toEqual({
+      playerName: "Alpha",
+      windowsPlayed: 6,
+      avgPoints: 268.33,
+      bestPoints: 320,
+      lastWindowPoints: 210,
+      consistencyScore: 1
+    });
+  });
+
+  it("computes decline rows using recent-3 vs baseline", () => {
+    const decline = buildClanWarsDeclineRows(rows);
+
+    expect(decline[0]).toEqual({
+      playerName: "Beta",
+      recentAvg: 63.33,
+      baselineAvg: 140,
+      delta: -76.67
+    });
+  });
+});

--- a/packages/platform/test/clan-wars-archive-metrics.test.ts
+++ b/packages/platform/test/clan-wars-archive-metrics.test.ts
@@ -6,24 +6,24 @@ import {
 } from "@raid/platform";
 
 const rows: ClanWarsPlayerWindowPointsRow[] = [
-  { windowStart: "2031-04-07T10:00:00.000Z", playerName: "Alpha", points: 210 },
-  { windowStart: "2031-04-07T10:00:00.000Z", playerName: "Beta", points: 40 },
-  { windowStart: "2031-04-07T10:00:00.000Z", playerName: "Gamma", points: 100 },
-  { windowStart: "2031-03-24T10:00:00.000Z", playerName: "Alpha", points: 240 },
-  { windowStart: "2031-03-24T10:00:00.000Z", playerName: "Beta", points: 60 },
-  { windowStart: "2031-03-24T10:00:00.000Z", playerName: "Gamma", points: 90 },
-  { windowStart: "2031-03-10T10:00:00.000Z", playerName: "Alpha", points: 260 },
-  { windowStart: "2031-03-10T10:00:00.000Z", playerName: "Beta", points: 90 },
-  { windowStart: "2031-03-10T10:00:00.000Z", playerName: "Gamma", points: 80 },
-  { windowStart: "2031-02-24T10:00:00.000Z", playerName: "Alpha", points: 280 },
-  { windowStart: "2031-02-24T10:00:00.000Z", playerName: "Beta", points: 120 },
-  { windowStart: "2031-02-24T10:00:00.000Z", playerName: "Gamma", points: 70 },
-  { windowStart: "2031-02-10T10:00:00.000Z", playerName: "Alpha", points: 300 },
-  { windowStart: "2031-02-10T10:00:00.000Z", playerName: "Beta", points: 140 },
-  { windowStart: "2031-02-10T10:00:00.000Z", playerName: "Gamma", points: 60 },
-  { windowStart: "2031-01-27T10:00:00.000Z", playerName: "Alpha", points: 320 },
-  { windowStart: "2031-01-27T10:00:00.000Z", playerName: "Beta", points: 160 },
-  { windowStart: "2031-01-27T10:00:00.000Z", playerName: "Gamma", points: 50 }
+  { windowStart: "2031-04-07T10:00:00.000Z", playerId: 1, playerName: "Alpha", points: 210 },
+  { windowStart: "2031-04-07T10:00:00.000Z", playerId: 2, playerName: "Beta", points: 40 },
+  { windowStart: "2031-04-07T10:00:00.000Z", playerId: 3, playerName: "Gamma", points: 100 },
+  { windowStart: "2031-03-24T10:00:00.000Z", playerId: 1, playerName: "Alpha", points: 240 },
+  { windowStart: "2031-03-24T10:00:00.000Z", playerId: 2, playerName: "Beta", points: 60 },
+  { windowStart: "2031-03-24T10:00:00.000Z", playerId: 3, playerName: "Gamma", points: 90 },
+  { windowStart: "2031-03-10T10:00:00.000Z", playerId: 1, playerName: "Alpha", points: 260 },
+  { windowStart: "2031-03-10T10:00:00.000Z", playerId: 2, playerName: "Beta", points: 90 },
+  { windowStart: "2031-03-10T10:00:00.000Z", playerId: 3, playerName: "Gamma", points: 80 },
+  { windowStart: "2031-02-24T10:00:00.000Z", playerId: 1, playerName: "Alpha", points: 280 },
+  { windowStart: "2031-02-24T10:00:00.000Z", playerId: 2, playerName: "Beta", points: 120 },
+  { windowStart: "2031-02-24T10:00:00.000Z", playerId: 3, playerName: "Gamma", points: 70 },
+  { windowStart: "2031-02-10T10:00:00.000Z", playerId: 1, playerName: "Alpha", points: 300 },
+  { windowStart: "2031-02-10T10:00:00.000Z", playerId: 2, playerName: "Beta", points: 140 },
+  { windowStart: "2031-02-10T10:00:00.000Z", playerId: 3, playerName: "Gamma", points: 60 },
+  { windowStart: "2031-01-27T10:00:00.000Z", playerId: 1, playerName: "Alpha", points: 320 },
+  { windowStart: "2031-01-27T10:00:00.000Z", playerId: 2, playerName: "Beta", points: 160 },
+  { windowStart: "2031-01-27T10:00:00.000Z", playerId: 3, playerName: "Gamma", points: 50 }
 ];
 
 describe("KT archive metrics", () => {
@@ -72,8 +72,8 @@ describe("KT archive metrics", () => {
   it("excludes players with fewer than three played windows from decline", () => {
     const withLowParticipation: ClanWarsPlayerWindowPointsRow[] = [
       ...rows,
-      { windowStart: "2031-04-07T10:00:00.000Z", playerName: "Delta", points: 40 },
-      { windowStart: "2031-03-24T10:00:00.000Z", playerName: "Delta", points: 50 }
+      { windowStart: "2031-04-07T10:00:00.000Z", playerId: 4, playerName: "Delta", points: 40 },
+      { windowStart: "2031-03-24T10:00:00.000Z", playerId: 4, playerName: "Delta", points: 50 }
     ];
 
     const decline = buildClanWarsDeclineRows(withLowParticipation);
@@ -97,5 +97,20 @@ describe("KT archive metrics", () => {
       ].includes(row.windowStart)
     );
     expect(buildClanWarsDeclineRows(threeWindowRows)).toEqual([]);
+  });
+
+  it("does not merge players that share nickname but have different player ids", () => {
+    const sameNameRows: ClanWarsPlayerWindowPointsRow[] = [
+      { windowStart: "2031-04-07T10:00:00.000Z", playerId: 10, playerName: "Echo", points: 120 },
+      { windowStart: "2031-03-24T10:00:00.000Z", playerId: 10, playerName: "Echo", points: 90 },
+      { windowStart: "2031-04-07T10:00:00.000Z", playerId: 11, playerName: "Echo", points: 30 },
+      { windowStart: "2031-03-24T10:00:00.000Z", playerId: 11, playerName: "Echo", points: 20 }
+    ];
+
+    const stability = buildClanWarsStabilityRows(sameNameRows, 2);
+
+    expect(stability).toHaveLength(2);
+    expect(stability.map((row) => row.playerName)).toEqual(["Echo", "Echo"]);
+    expect(stability.map((row) => row.avgPoints)).toEqual([105, 25]);
   });
 });

--- a/packages/platform/test/clan-wars-archive-metrics.test.ts
+++ b/packages/platform/test/clan-wars-archive-metrics.test.ts
@@ -48,6 +48,12 @@ describe("KT archive metrics", () => {
     expect(buildClanWarsStabilityRows(rows, -2)).toEqual([]);
   });
 
+  it("returns empty stability rows when selected windows is not a valid positive integer", () => {
+    expect(buildClanWarsStabilityRows(rows, Number.NaN)).toEqual([]);
+    expect(buildClanWarsStabilityRows(rows, Number.POSITIVE_INFINITY)).toEqual([]);
+    expect(buildClanWarsStabilityRows(rows, 1.5)).toEqual([]);
+  });
+
   it("computes decline rows using recent-3 vs baseline with only negative deltas", () => {
     const decline = buildClanWarsDeclineRows(rows);
 

--- a/packages/platform/test/clan-wars-archive-metrics.test.ts
+++ b/packages/platform/test/clan-wars-archive-metrics.test.ts
@@ -27,8 +27,11 @@ const rows: ClanWarsPlayerWindowPointsRow[] = [
 ];
 
 describe("KT archive metrics", () => {
-  it("computes stability rows from player-window matrix", () => {
+  it("computes stability rows from player-window matrix with deterministic ordering", () => {
     const stability = buildClanWarsStabilityRows(rows, 6);
+
+    expect(stability).toHaveLength(3);
+    expect(stability.map((row) => row.playerName)).toEqual(["Alpha", "Beta", "Gamma"]);
 
     expect(stability[0]).toEqual({
       playerName: "Alpha",
@@ -40,8 +43,17 @@ describe("KT archive metrics", () => {
     });
   });
 
-  it("computes decline rows using recent-3 vs baseline", () => {
+  it("returns empty stability rows when selected windows is zero or negative", () => {
+    expect(buildClanWarsStabilityRows(rows, 0)).toEqual([]);
+    expect(buildClanWarsStabilityRows(rows, -2)).toEqual([]);
+  });
+
+  it("computes decline rows using recent-3 vs baseline with only negative deltas", () => {
     const decline = buildClanWarsDeclineRows(rows);
+
+    expect(decline).toHaveLength(2);
+    expect(decline.map((row) => row.playerName)).toEqual(["Beta", "Alpha"]);
+    expect(decline.every((row) => row.delta < 0)).toBe(true);
 
     expect(decline[0]).toEqual({
       playerName: "Beta",
@@ -49,5 +61,35 @@ describe("KT archive metrics", () => {
       baselineAvg: 140,
       delta: -76.67
     });
+  });
+
+  it("excludes players with fewer than three played windows from decline", () => {
+    const withLowParticipation: ClanWarsPlayerWindowPointsRow[] = [
+      ...rows,
+      { windowStart: "2031-04-07T10:00:00.000Z", playerName: "Delta", points: 40 },
+      { windowStart: "2031-03-24T10:00:00.000Z", playerName: "Delta", points: 50 }
+    ];
+
+    const decline = buildClanWarsDeclineRows(withLowParticipation);
+
+    expect(decline.some((row) => row.playerName === "Delta")).toBe(false);
+  });
+
+  it("returns empty decline rows for empty or insufficient window history", () => {
+    expect(buildClanWarsDeclineRows([])).toEqual([]);
+
+    const twoWindowRows = rows.filter((row) =>
+      ["2031-04-07T10:00:00.000Z", "2031-03-24T10:00:00.000Z"].includes(row.windowStart)
+    );
+    expect(buildClanWarsDeclineRows(twoWindowRows)).toEqual([]);
+
+    const threeWindowRows = rows.filter((row) =>
+      [
+        "2031-04-07T10:00:00.000Z",
+        "2031-03-24T10:00:00.000Z",
+        "2031-03-10T10:00:00.000Z"
+      ].includes(row.windowStart)
+    );
+    expect(buildClanWarsDeclineRows(threeWindowRows)).toEqual([]);
   });
 });

--- a/packages/platform/test/helpers/clan-dashboard-query-check.mjs
+++ b/packages/platform/test/helpers/clan-dashboard-query-check.mjs
@@ -89,7 +89,7 @@ WITH recent_windows AS (
       LIMIT 1
     )
   WHERE cw.activity_type = 'clan_wars'
-    AND cw.starts_at <= ?
+    AND cw.ends_at <= ?
   ORDER BY cw.starts_at DESC, cw.id DESC
   LIMIT ?
 )

--- a/packages/platform/test/helpers/clan-dashboard-query-check.mjs
+++ b/packages/platform/test/helpers/clan-dashboard-query-check.mjs
@@ -73,37 +73,50 @@ LEFT JOIN latest_report lr ON 1 = 1;
 
 const selectClanWarsArchiveHistorySql = `
 WITH recent_windows AS (
-  SELECT id, starts_at, ends_at
-  FROM competition_window
-  WHERE activity_type = 'clan_wars'
-  ORDER BY starts_at DESC, id DESC
+  SELECT
+    cw.id,
+    cw.starts_at,
+    cw.ends_at,
+    cwr.id AS report_id,
+    cwr.has_personal_rewards
+  FROM competition_window cw
+  JOIN clan_wars_report cwr
+    ON cwr.id = (
+      SELECT cwr2.id
+      FROM clan_wars_report cwr2
+      WHERE cwr2.competition_window_id = cw.id
+      ORDER BY cwr2.created_at DESC, cwr2.id DESC
+      LIMIT 1
+    )
+  WHERE cw.activity_type = 'clan_wars'
+    AND cw.starts_at <= ?
+  ORDER BY cw.starts_at DESC, cw.id DESC
   LIMIT ?
 )
 SELECT
   rw.starts_at,
-  COALESCE(cwr.has_personal_rewards, 0) AS has_personal_rewards,
+  rw.has_personal_rewards AS has_personal_rewards,
   COALESCE(SUM(cwps.points), 0) AS clan_total_points,
   COALESCE(COUNT(DISTINCT CASE WHEN cwps.points > 0 THEN cwps.player_profile_id END), 0) AS active_contributors,
   COALESCE((
-    SELECT pp2.main_nickname
+    SELECT pp.main_nickname
     FROM clan_wars_player_score cwps2
-    JOIN player_profile pp2 ON pp2.id = cwps2.player_profile_id
-    WHERE cwps2.competition_window_id = rw.id
-    ORDER BY cwps2.points DESC, pp2.main_nickname ASC
+    JOIN player_profile pp ON pp.id = cwps2.player_profile_id
+    WHERE cwps2.clan_wars_report_id = rw.report_id
+    ORDER BY cwps2.points DESC, pp.main_nickname ASC
     LIMIT 1
   ), '-') AS top_player_name,
   COALESCE((
     SELECT cwps2.points
     FROM clan_wars_player_score cwps2
-    JOIN player_profile pp2 ON pp2.id = cwps2.player_profile_id
-    WHERE cwps2.competition_window_id = rw.id
-    ORDER BY cwps2.points DESC, pp2.main_nickname ASC
+    JOIN player_profile pp ON pp.id = cwps2.player_profile_id
+    WHERE cwps2.clan_wars_report_id = rw.report_id
+    ORDER BY cwps2.points DESC, pp.main_nickname ASC
     LIMIT 1
   ), 0) AS top_player_points
 FROM recent_windows rw
-LEFT JOIN clan_wars_report cwr ON cwr.competition_window_id = rw.id
-LEFT JOIN clan_wars_player_score cwps ON cwps.competition_window_id = rw.id
-GROUP BY rw.id, rw.starts_at, cwr.has_personal_rewards
+LEFT JOIN clan_wars_player_score cwps ON cwps.clan_wars_report_id = rw.report_id
+GROUP BY rw.id, rw.starts_at, rw.has_personal_rewards, rw.report_id
 ORDER BY rw.starts_at DESC, rw.id DESC;
 `;
 
@@ -431,7 +444,9 @@ const runKtArchiveHistoryAggregate = (database) => {
   insertScore(previousReportId, previousWindowId, alpha, "Alpha", 180);
   insertScore(previousReportId, previousWindowId, beta, "Beta", 50);
 
-  const rows = database.prepare(selectClanWarsArchiveHistorySql).all(12);
+  const rows = database
+    .prepare(selectClanWarsArchiveHistorySql)
+    .all("2031-05-01T00:00:00Z", 12);
 
   emit({
     ok: true,

--- a/packages/platform/test/helpers/clan-dashboard-query-check.mjs
+++ b/packages/platform/test/helpers/clan-dashboard-query-check.mjs
@@ -71,6 +71,42 @@ FROM latest_window lw
 LEFT JOIN latest_report lr ON 1 = 1;
 `;
 
+const selectClanWarsArchiveHistorySql = `
+WITH recent_windows AS (
+  SELECT id, starts_at, ends_at
+  FROM competition_window
+  WHERE activity_type = 'clan_wars'
+  ORDER BY starts_at DESC, id DESC
+  LIMIT ?
+)
+SELECT
+  rw.starts_at,
+  COALESCE(cwr.has_personal_rewards, 0) AS has_personal_rewards,
+  COALESCE(SUM(cwps.points), 0) AS clan_total_points,
+  COALESCE(COUNT(DISTINCT CASE WHEN cwps.points > 0 THEN cwps.player_profile_id END), 0) AS active_contributors,
+  COALESCE((
+    SELECT pp2.main_nickname
+    FROM clan_wars_player_score cwps2
+    JOIN player_profile pp2 ON pp2.id = cwps2.player_profile_id
+    WHERE cwps2.competition_window_id = rw.id
+    ORDER BY cwps2.points DESC, pp2.main_nickname ASC
+    LIMIT 1
+  ), '-') AS top_player_name,
+  COALESCE((
+    SELECT cwps2.points
+    FROM clan_wars_player_score cwps2
+    JOIN player_profile pp2 ON pp2.id = cwps2.player_profile_id
+    WHERE cwps2.competition_window_id = rw.id
+    ORDER BY cwps2.points DESC, pp2.main_nickname ASC
+    LIMIT 1
+  ), 0) AS top_player_points
+FROM recent_windows rw
+LEFT JOIN clan_wars_report cwr ON cwr.competition_window_id = rw.id
+LEFT JOIN clan_wars_player_score cwps ON cwps.competition_window_id = rw.id
+GROUP BY rw.id, rw.starts_at, cwr.has_personal_rewards
+ORDER BY rw.starts_at DESC, rw.id DESC;
+`;
+
 const applyMigrations = () => {
   const database = new DatabaseSync(":memory:");
 
@@ -309,6 +345,100 @@ const runClanWarsReadinessScopedStatus = (database) => {
   });
 };
 
+const runKtArchiveHistoryAggregate = (database) => {
+  const alpha = insertPlayer(database, "Alpha");
+  const beta = insertPlayer(database, "Beta");
+  const gamma = insertPlayer(database, "Gamma");
+
+  const latestWindowId = insertCompetitionWindow(database, {
+    activityType: "clan_wars",
+    seasonYear: 2031,
+    week: 11,
+    cadence: "biweekly",
+    rotationNumber: null,
+    startsAt: "2031-04-12T00:00:00Z",
+    endsAt: "2031-04-14T00:00:00Z",
+    label: "cw-a"
+  });
+
+  const previousWindowId = insertCompetitionWindow(database, {
+    activityType: "clan_wars",
+    seasonYear: 2031,
+    week: 10,
+    cadence: "biweekly",
+    rotationNumber: null,
+    startsAt: "2031-03-29T00:00:00Z",
+    endsAt: "2031-03-31T00:00:00Z",
+    label: "cw-b"
+  });
+
+  const latestImportId = insertReportImport(database, "cw-a");
+  const previousImportId = insertReportImport(database, "cw-b");
+
+  const latestReportId = Number(
+    database
+      .prepare(
+        [
+          "INSERT INTO clan_wars_report",
+          "(competition_window_id, report_import_id, source_system, is_partial, has_personal_rewards, created_at)",
+          "VALUES (?, ?, ?, ?, ?, ?)"
+        ].join(" ")
+      )
+      .run(
+        latestWindowId,
+        latestImportId,
+        "unit",
+        0,
+        1,
+        "2031-04-12T02:00:00Z"
+      ).lastInsertRowid
+  );
+
+  const previousReportId = Number(
+    database
+      .prepare(
+        [
+          "INSERT INTO clan_wars_report",
+          "(competition_window_id, report_import_id, source_system, is_partial, has_personal_rewards, created_at)",
+          "VALUES (?, ?, ?, ?, ?, ?)"
+        ].join(" ")
+      )
+      .run(
+        previousWindowId,
+        previousImportId,
+        "unit",
+        0,
+        0,
+        "2031-03-29T02:00:00Z"
+      ).lastInsertRowid
+  );
+
+  const insertScore = (reportId, windowId, playerId, playerName, points) => {
+    database
+      .prepare(
+        [
+          "INSERT INTO clan_wars_player_score",
+          "(clan_wars_report_id, competition_window_id, player_profile_id, display_name_at_import, points)",
+          "VALUES (?, ?, ?, ?, ?)"
+        ].join(" ")
+      )
+      .run(reportId, windowId, playerId, playerName, points);
+  };
+
+  insertScore(latestReportId, latestWindowId, alpha, "Alpha", 220);
+  insertScore(latestReportId, latestWindowId, beta, "Beta", 110);
+  insertScore(latestReportId, latestWindowId, gamma, "Gamma", 100);
+  insertScore(previousReportId, previousWindowId, alpha, "Alpha", 180);
+  insertScore(previousReportId, previousWindowId, beta, "Beta", 50);
+
+  const rows = database.prepare(selectClanWarsArchiveHistorySql).all(12);
+
+  emit({
+    ok: true,
+    rows
+  });
+};
+
 const database = applyMigrations();
 const command = process.argv[2];
 
@@ -321,6 +451,9 @@ switch (command) {
     break;
   case "kt-readiness-window-scoped-status":
     runClanWarsReadinessScopedStatus(database);
+    break;
+  case "kt-archive-history-aggregate":
+    runKtArchiveHistoryAggregate(database);
     break;
   default:
     emit({ ok: false, error: `unknown-command:${command}` });

--- a/packages/platform/test/helpers/clan-dashboard-query-check.mjs
+++ b/packages/platform/test/helpers/clan-dashboard-query-check.mjs
@@ -95,6 +95,7 @@ WITH recent_windows AS (
 )
 SELECT
   rw.starts_at,
+  rw.ends_at,
   rw.has_personal_rewards AS has_personal_rewards,
   COALESCE(SUM(cwps.points), 0) AS clan_total_points,
   COALESCE(COUNT(DISTINCT CASE WHEN cwps.points > 0 THEN cwps.player_profile_id END), 0) AS active_contributors,
@@ -116,7 +117,7 @@ SELECT
   ), 0) AS top_player_points
 FROM recent_windows rw
 LEFT JOIN clan_wars_player_score cwps ON cwps.clan_wars_report_id = rw.report_id
-GROUP BY rw.id, rw.starts_at, rw.has_personal_rewards, rw.report_id
+GROUP BY rw.id, rw.starts_at, rw.ends_at, rw.has_personal_rewards, rw.report_id
 ORDER BY rw.starts_at DESC, rw.id DESC;
 `;
 

--- a/packages/ports/src/repositories/clan-dashboard-repository.ts
+++ b/packages/ports/src/repositories/clan-dashboard-repository.ts
@@ -50,6 +50,47 @@ export type ClanDashboardData = {
   };
 };
 
+export type ClanWarsHeader = {
+  targetAt: string;
+  targetKind: "start" | "reset";
+  eventStartAt: string;
+  eventEndsAt: string;
+  hasPersonalRewards: boolean;
+};
+
+export type ClanWarsArchiveHistoryRow = {
+  windowStart: string;
+  windowEnd: string;
+  hasPersonalRewards: boolean;
+  clanTotalPoints: number;
+  activeContributors: number;
+  topPlayerName: string;
+  topPlayerPoints: number;
+};
+
+export type ClanWarsArchiveStabilityRow = {
+  playerName: string;
+  windowsPlayed: number;
+  avgPoints: number;
+  bestPoints: number;
+  lastWindowPoints: number;
+  consistencyScore: number;
+};
+
+export type ClanWarsArchiveDeclineRow = {
+  playerName: string;
+  recentAvg: number;
+  baselineAvg: number;
+  delta: number;
+};
+
+export type ClanWarsArchiveData = {
+  header: ClanWarsHeader;
+  history: ClanWarsArchiveHistoryRow[];
+  stability: ClanWarsArchiveStabilityRow[];
+  decline: ClanWarsArchiveDeclineRow[];
+};
+
 export type SiegeDefenseSource = {
   getCurrentRanking(): DashboardTopBottom;
 };
@@ -76,4 +117,8 @@ export type ClanDashboardSnapshot = {
 
 export type ClanDashboardRepository = {
   getSnapshot(input: { nowIso: string; trendWeeks: number }): Promise<ClanDashboardData>;
+};
+
+export type ClanWarsArchiveRepository = {
+  getClanWarsArchive(input: { nowIso: string; windowLimit: number }): Promise<ClanWarsArchiveData>;
 };


### PR DESCRIPTION
## Summary
- add dedicated archive-first KT page at `/dashboard/clan-wars` with countdown header, history table, roster stability, and decline zones
- add direct `KT` link in dashboard navigation and validate it with targeted regression assertions
- implement KT archive snapshot pipeline end-to-end across ports/application/platform (contracts, use case, D1 SQL, repository mapping)
- harden archive data logic after review:
  - include only historical reported KT windows
  - join score rows through `clan_wars_report_id`
  - use stable `playerId` grouping to avoid nickname-collision merges
- expand coverage for empty states, top-10 truncation behavior, helper/runtime SQL parity, and repository-level KT archive mapping

## Test Plan
- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm -r run build`
- [x] `pnpm --filter @raid/web run cf:build`
- [x] `pnpm test -- packages/platform/test/clan-wars-archive-metrics.test.ts packages/platform/test/clan-dashboard-repository.test.ts packages/application/test/get-clan-wars-archive-snapshot.test.ts apps/web/src/app/dashboard/clan-wars/page.test.tsx apps/web/src/app/dashboard/page.test.tsx`
