### PR TITLE
fix: hotfix OCR artifacts in clan wars historical points

### DIFF
--- a/platform/migrations/0006_clan_wars_ocr_points_hotfix.sql
+++ b/platform/migrations/0006_clan_wars_ocr_points_hotfix.sql
@@ -1,0 +1,36 @@
+-- Hotfix for known OCR artifacts in historical clan wars import.
+-- Some rows imported by 0005 had an extra leading digit in points.
+
+UPDATE clan_wars_player_score
+SET points = 117545
+WHERE points = 2117545
+  AND player_profile_id IN (
+    SELECT id
+    FROM player_profile
+    WHERE main_nickname = '(BiБр) Крегул'
+  )
+  AND clan_wars_report_id IN (
+    SELECT cwr.id
+    FROM clan_wars_report cwr
+    JOIN competition_window cw ON cw.id = cwr.competition_window_id
+    WHERE cw.activity_type = 'clan_wars'
+      AND cw.starts_at = '2026-02-24T00:00:00Z'
+      AND cw.ends_at = '2026-02-26T00:00:00Z'
+  );
+
+UPDATE clan_wars_player_score
+SET points = 154714
+WHERE points = 1154714
+  AND player_profile_id IN (
+    SELECT id
+    FROM player_profile
+    WHERE main_nickname = 'Nightfear'
+  )
+  AND clan_wars_report_id IN (
+    SELECT cwr.id
+    FROM clan_wars_report cwr
+    JOIN competition_window cw ON cw.id = cwr.competition_window_id
+    WHERE cw.activity_type = 'clan_wars'
+      AND cw.starts_at = '2026-01-13T00:00:00Z'
+      AND cw.ends_at = '2026-01-15T00:00:00Z'
+  );

--- a/platform/migrations/0007_clan_wars_historical_rewards_hotfix.sql
+++ b/platform/migrations/0007_clan_wars_historical_rewards_hotfix.sql
@@ -1,0 +1,15 @@
+-- Hotfix for confirmed historical clan wars rewards status.
+-- OCR historical import (0005) defaulted has_personal_rewards to 0 for all windows.
+-- This migration marks manually confirmed windows with personal rewards.
+
+UPDATE clan_wars_report
+SET has_personal_rewards = 1
+WHERE has_personal_rewards = 0
+  AND source_system = 'historical-clan-wars-ocr'
+  AND competition_window_id IN (
+    SELECT id
+    FROM competition_window
+    WHERE activity_type = 'clan_wars'
+      AND starts_at = '2026-01-13T00:00:00Z'
+      AND ends_at = '2026-01-15T00:00:00Z'
+  );

--- a/platform/migrations/0008_clan_wars_historical_rewards_from_ocr_tool.sql
+++ b/platform/migrations/0008_clan_wars_historical_rewards_from_ocr_tool.sql
@@ -1,0 +1,30 @@
+-- Inferred from tool/ocr-clan-results over ~/Downloads/clanwars resources.
+-- Decision rule: explicit OCR marker for "Личные награды" on the clan wars page.
+
+WITH inferred_windows(starts_at, ends_at, source_file) AS (
+  VALUES
+    ('2025-04-08T00:00:00Z', '2025-04-10T00:00:00Z', '10.04.25.jpg'),
+    ('2025-05-06T00:00:00Z', '2025-05-08T00:00:00Z', '08.05.25.jpg'),
+    ('2025-07-29T00:00:00Z', '2025-07-31T00:00:00Z', '31.07.25.jpg'),
+    ('2025-08-26T00:00:00Z', '2025-08-28T00:00:00Z', '28.08.25.jpg'),
+    ('2025-09-23T00:00:00Z', '2025-09-25T00:00:00Z', '25.09.25.jpg'),
+    ('2025-10-21T00:00:00Z', '2025-10-23T00:00:00Z', '23.10.25.jpg'),
+    ('2025-11-18T00:00:00Z', '2025-11-20T00:00:00Z', '20.11.25.jpg'),
+    ('2025-12-16T00:00:00Z', '2025-12-18T00:00:00Z', '18.12.25.jpg'),
+    ('2026-01-13T00:00:00Z', '2026-01-15T00:00:00Z', '15.01.26.jpg'),
+    ('2026-02-10T00:00:00Z', '2026-02-12T00:00:00Z', '12.02.26.jpg'),
+    ('2026-03-10T00:00:00Z', '2026-03-12T00:00:00Z', '11.03.26.jpg'),
+    ('2026-04-07T00:00:00Z', '2026-04-09T00:00:00Z', '08.04.26.jpg')
+)
+UPDATE clan_wars_report
+SET has_personal_rewards = 1
+WHERE source_system = 'historical-clan-wars-ocr'
+  AND has_personal_rewards = 0
+  AND competition_window_id IN (
+    SELECT cw.id
+    FROM competition_window cw
+    JOIN inferred_windows iw
+      ON iw.starts_at = cw.starts_at
+     AND iw.ends_at = cw.ends_at
+    WHERE cw.activity_type = 'clan_wars'
+  );

--- a/tool/ocr-clan-results/README.md
+++ b/tool/ocr-clan-results/README.md
@@ -1,0 +1,36 @@
+# ocr-clan-results
+
+Swift CLI for OCR parsing of clan wars report pages and inference of `has_personal_rewards`.
+
+## What it does
+
+- Reads image (`.jpg/.jpeg/.png`) and markdown (`.md/.txt`) resources.
+- Runs Vision OCR for images.
+- Builds canonical JSON for each page (`page ocr clan wars` model).
+- Infers `has_personal_rewards` using OCR markers (currently marker-based: `"Личные награды"` family).
+- Produces run report JSON with a ready list of windows to mark as personal rewards.
+
+## Canonical model
+
+Schema for one page:
+- `schema/page-ocr-clan-wars.schema.json`
+
+The tool output is a run report with:
+- `pages[]` (array of canonical page models)
+- `recommendedPersonalRewardsWindows[]` (inferred windows for DB update)
+
+## Usage
+
+```bash
+swift tool/ocr-clan-results/ocr-clan-results.swift \
+  --input /Users/$USER/Downloads/clanwars \
+  --output tool/ocr-clan-results/out/clanwars-ocr-report.json \
+  --min-confidence 0.8
+```
+
+## Notes
+
+- Window boundaries are derived from file names like `15.01.26.jpg`:
+  - end date: `2026-01-15`
+  - start date: `end - 2 days`
+- Files that do not match `dd.MM.yy*` are still OCR-processed, but do not produce a tournament window key.

--- a/tool/ocr-clan-results/README.md
+++ b/tool/ocr-clan-results/README.md
@@ -21,20 +21,30 @@ Schemas:
 
 ```bash
 swift tool/ocr-clan-results/ocr-clan-results.swift \
-  --input /Users/$USER/Downloads/clanwars \
-  --output tool/ocr-clan-results/out/clanwars-canonical-import.json
+  --image /Users/$USER/Downloads/clanwars/10.04.25.jpg \
+  --participants-json /absolute/path/to/clan-members.json \
+  --output tool/ocr-clan-results/out/page-ocr-clan-wars.json
 ```
+
+Participants JSON accepted shapes:
+
+- `["Nick1", "Nick2"]`
+- `{ "participants": ["Nick1", "Nick2"] }`
+- `{ "players": [{ "nick": "Nick1" }, { "mainNickname": "Nick2" }] }`
+
+The tool auto-corrects recognized nicknames to the nearest clan participant using string distance.
 
 Render SQL stubs from canonical JSON:
 
 ```bash
 swift tool/ocr-clan-results/render-import-sql.swift \
-  tool/ocr-clan-results/out/clanwars-canonical-import.json \
+  tool/ocr-clan-results/out/page-ocr-clan-wars.json \
   tool/ocr-clan-results/out/clanwars-canonical-import.sql
 ```
 
 ## Notes
 
-- The tool maps screenshots to KT windows using bi-weekly calendar anchoring from `2025-03-25T00:00:00Z`.
+- The tool maps screenshot date to KT window using bi-weekly calendar anchoring from `2025-03-25T00:00:00Z`.
 - Opponent player breakdown is intentionally not extracted.
 - Output is intentionally import-focused: no confidence/debug fields in canonical records.
+- The tool validates `sum(playersOurs.points)` against OCR `totals.mine`. If mismatch is above `1%` (configurable via `--max-mine-total-diff-ratio`), it exits with code `2`.

--- a/tool/ocr-clan-results/README.md
+++ b/tool/ocr-clan-results/README.md
@@ -1,36 +1,40 @@
 # ocr-clan-results
 
-Swift CLI for OCR parsing of clan wars report pages and inference of `has_personal_rewards`.
+Swift CLI for OCR extraction of clan wars pages into a canonical import model.
 
-## What it does
+## Canonical model (for import)
 
-- Reads image (`.jpg/.jpeg/.png`) and markdown (`.md/.txt`) resources.
-- Runs Vision OCR for images.
-- Builds canonical JSON for each page (`page ocr clan wars` model).
-- Infers `has_personal_rewards` using OCR markers (currently marker-based: `"Личные награды"` family).
-- Produces run report JSON with a ready list of windows to mark as personal rewards.
+Each tournament record contains only import-relevant fields:
 
-## Canonical model
+- `startsAt`, `endsAt`
+- `hasPersonalRewards` (`0|1`)
+- `opponentClanName`
+- `totals` (`mine` vs `opponent`)
+- `playersOurs` (`rank`, `playerNick`, `points`)
 
-Schema for one page:
-- `schema/page-ocr-clan-wars.schema.json`
+Schemas:
 
-The tool output is a run report with:
-- `pages[]` (array of canonical page models)
-- `recommendedPersonalRewardsWindows[]` (inferred windows for DB update)
+- `schema/page-ocr-clan-wars.schema.json` (single tournament import record)
+- `schema/run-report.schema.json` (full OCR run report)
 
 ## Usage
 
 ```bash
 swift tool/ocr-clan-results/ocr-clan-results.swift \
   --input /Users/$USER/Downloads/clanwars \
-  --output tool/ocr-clan-results/out/clanwars-ocr-report.json \
-  --min-confidence 0.8
+  --output tool/ocr-clan-results/out/clanwars-canonical-import.json
+```
+
+Render SQL stubs from canonical JSON:
+
+```bash
+swift tool/ocr-clan-results/render-import-sql.swift \
+  tool/ocr-clan-results/out/clanwars-canonical-import.json \
+  tool/ocr-clan-results/out/clanwars-canonical-import.sql
 ```
 
 ## Notes
 
-- Window boundaries are derived from file names like `15.01.26.jpg`:
-  - end date: `2026-01-15`
-  - start date: `end - 2 days`
-- Files that do not match `dd.MM.yy*` are still OCR-processed, but do not produce a tournament window key.
+- The tool maps screenshots to KT windows using bi-weekly calendar anchoring from `2025-03-25T00:00:00Z`.
+- Opponent player breakdown is intentionally not extracted.
+- Output is intentionally import-focused: no confidence/debug fields in canonical records.

--- a/tool/ocr-clan-results/ocr-clan-results.swift
+++ b/tool/ocr-clan-results/ocr-clan-results.swift
@@ -9,63 +9,57 @@ enum SourceType: String, Codable {
   case markdown
 }
 
-struct OCRLine: Codable {
-  let text: String
-  let confidence: Double
-  let boundingBox: [Double]
+struct ClanWarsTotals: Codable {
+  let mine: Int?
+  let opponent: Int?
 }
 
-struct TournamentWindow: Codable {
-  let sourceReportKey: String
-  let startsOn: String
-  let endsOn: String
-  let startsAtUtc: String
-  let endsAtUtc: String
+struct ClanWarsPlayerBreakdown: Codable {
+  let rank: Int
+  let playerNick: String
+  let points: Int
 }
 
-struct RewardInference: Codable {
-  let hasPersonalRewards: Bool
-  let confidence: Double
-  let decision: String
-  let evidence: [String]
-}
-
-struct OCRPageClanWars: Codable {
-  let fileName: String
-  let sourceType: SourceType
-  let window: TournamentWindow?
-  let rewardInference: RewardInference
-  let lineCount: Int
-  let lines: [OCRLine]
-}
-
-struct WindowRecommendation: Codable {
-  let sourceReportKey: String
-  let startsAtUtc: String
-  let endsAtUtc: String
-  let confidence: Double
-  let evidence: [String]
+struct ClanWarsTournamentImport: Codable {
   let sourceFile: String
+  let sourceType: SourceType
+  let sourceReportKey: String
+  let startsAt: String
+  let endsAt: String
+  let hasPersonalRewards: Int
+  let opponentClanName: String?
+  let totals: ClanWarsTotals
+  let playersOurs: [ClanWarsPlayerBreakdown]
 }
 
-struct OCRRunReport: Codable {
+struct CanonicalClanWarsImportReport: Codable {
   let generatedAt: String
   let inputDirectory: String
-  let modelName: String
-  let pages: [OCRPageClanWars]
-  let recommendedPersonalRewardsWindows: [WindowRecommendation]
+  let activity: String
+  let tournaments: [ClanWarsTournamentImport]
 }
 
 struct CLIOptions {
   let inputDirectory: String
   let outputPath: String
-  let minConfidence: Double
+}
+
+struct OCRToken {
+  let text: String
+  let x: Double
+  let y: Double
+  let confidence: Double
+}
+
+struct TournamentWindow {
+  let sourceReportKey: String
+  let startsAt: String
+  let endsAt: String
 }
 
 func parseOptions() -> CLIOptions {
   var inputDirectory = NSHomeDirectory() + "/Downloads/clanwars"
-  var outputPath = "tool/ocr-clan-results/out/clanwars-ocr-report.json"
-  var minConfidence = 0.8
+  var outputPath = "tool/ocr-clan-results/out/clanwars-canonical-import.json"
 
   var index = 1
   while index < CommandLine.arguments.count {
@@ -81,70 +75,54 @@ func parseOptions() -> CLIOptions {
       if index < CommandLine.arguments.count {
         outputPath = CommandLine.arguments[index]
       }
-    case "--min-confidence":
-      index += 1
-      if index < CommandLine.arguments.count, let value = Double(CommandLine.arguments[index]) {
-        minConfidence = value
-      }
     default:
       break
     }
     index += 1
   }
 
-  return CLIOptions(inputDirectory: inputDirectory, outputPath: outputPath, minConfidence: minConfidence)
+  return CLIOptions(inputDirectory: inputDirectory, outputPath: outputPath)
 }
 
 func normalized(_ value: String) -> String {
   let lowered = value.lowercased()
-  let mapped = lowered.replacingOccurrences(of: "ё", with: "е")
+  let mapped = lowered
+    .replacingOccurrences(of: "ё", with: "е")
+    .replacingOccurrences(of: "і", with: "и")
   let collapsed = mapped.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
   return collapsed.trimmingCharacters(in: .whitespacesAndNewlines)
 }
 
-func inferRewards(from lines: [OCRLine]) -> RewardInference {
-  let normalizedLines = lines.map { normalized($0.text) }
+func digitsOnly(_ value: String) -> String {
+  String(value.unicodeScalars.filter { CharacterSet.decimalDigits.contains($0) })
+}
 
-  let positivePatterns = [
-    "личные награды",
-    "личные",
-    "лиичные",
-    "nuyhbie",
-    "nu4hbie",
-    "личн"
-  ]
-
-  var evidence: [String] = []
-  var topConfidence = 0.0
-
-  for (idx, line) in normalizedLines.enumerated() {
-    if positivePatterns.contains(where: { line.contains($0) }) {
-      evidence.append(lines[idx].text)
-      topConfidence = max(topConfidence, lines[idx].confidence)
-    }
+func parseInt(_ value: String) -> Int? {
+  let digits = digitsOnly(value)
+  guard !digits.isEmpty else {
+    return nil
   }
+  return Int(digits)
+}
 
-  if !evidence.isEmpty {
-    return RewardInference(
-      hasPersonalRewards: true,
-      confidence: max(0.8, topConfidence),
-      decision: "confirmed_by_ocr_marker",
-      evidence: Array(evidence.prefix(5))
-    )
+func parseIntClamped(_ value: String, max: Int) -> Int? {
+  var digits = digitsOnly(value)
+  while let number = Int(digits), number > max, digits.count > 1 {
+    digits.removeLast()
   }
+  return Int(digits)
+}
 
-  return RewardInference(
-    hasPersonalRewards: false,
-    confidence: 0.6,
-    decision: "marker_not_found",
-    evidence: []
-  )
+func containsLetter(_ value: String) -> Bool {
+  value.unicodeScalars.contains { CharacterSet.letters.contains($0) }
 }
 
 func parseCaptureDate(from fileName: String) -> Date? {
-  let pattern = #"^(\d{2})\.(\d{2})\.(\d{2})"#
-  guard
-    let regex = try? NSRegularExpression(pattern: pattern),
+  let calendar = Calendar(identifier: .gregorian)
+
+  let numericPattern = #"^(\d{2})\.(\d{2})\.(\d{2})"#
+  if
+    let regex = try? NSRegularExpression(pattern: numericPattern),
     let match = regex.firstMatch(in: fileName, range: NSRange(location: 0, length: fileName.utf16.count)),
     let dayRange = Range(match.range(at: 1), in: fileName),
     let monthRange = Range(match.range(at: 2), in: fileName),
@@ -152,22 +130,56 @@ func parseCaptureDate(from fileName: String) -> Date? {
     let day = Int(fileName[dayRange]),
     let month = Int(fileName[monthRange]),
     let yearShort = Int(fileName[yearRange])
-  else {
-    return nil
+  {
+    var comps = DateComponents()
+    comps.year = 2000 + yearShort
+    comps.month = month
+    comps.day = day
+    comps.hour = 0
+    comps.minute = 0
+    comps.second = 0
+    comps.timeZone = TimeZone(secondsFromGMT: 0)
+    return calendar.date(from: comps)
   }
 
-  let year = 2000 + yearShort
-  var comps = DateComponents()
-  comps.year = year
-  comps.month = month
-  comps.day = day
-  comps.hour = 0
-  comps.minute = 0
-  comps.second = 0
-  comps.timeZone = TimeZone(secondsFromGMT: 0)
+  let englishPattern = #"^(january|february|march|april|may|june|july|august|september|october|november|december)-(\d{1,2})-clanwars-report"#
+  if
+    let regex = try? NSRegularExpression(pattern: englishPattern),
+    let match = regex.firstMatch(in: fileName.lowercased(), range: NSRange(location: 0, length: fileName.utf16.count)),
+    let monthRange = Range(match.range(at: 1), in: fileName.lowercased()),
+    let dayRange = Range(match.range(at: 2), in: fileName.lowercased()),
+    let day = Int(fileName.lowercased()[dayRange])
+  {
+    let monthMap: [String: Int] = [
+      "january": 1,
+      "february": 2,
+      "march": 3,
+      "april": 4,
+      "may": 5,
+      "june": 6,
+      "july": 7,
+      "august": 8,
+      "september": 9,
+      "october": 10,
+      "november": 11,
+      "december": 12
+    ]
+    guard let month = monthMap[String(fileName.lowercased()[monthRange])] else {
+      return nil
+    }
 
-  let calendar = Calendar(identifier: .gregorian)
-  return calendar.date(from: comps)
+    var comps = DateComponents()
+    comps.year = 2025
+    comps.month = month
+    comps.day = day
+    comps.hour = 0
+    comps.minute = 0
+    comps.second = 0
+    comps.timeZone = TimeZone(secondsFromGMT: 0)
+    return calendar.date(from: comps)
+  }
+
+  return nil
 }
 
 func parseWindow(from fileName: String) -> TournamentWindow? {
@@ -184,6 +196,7 @@ func parseWindow(from fileName: String) -> TournamentWindow? {
   anchorComps.minute = 0
   anchorComps.second = 0
   anchorComps.timeZone = TimeZone(secondsFromGMT: 0)
+
   guard let anchorStart = calendar.date(from: anchorComps) else {
     return nil
   }
@@ -211,31 +224,17 @@ func parseWindow(from fileName: String) -> TournamentWindow? {
 
   let startsOn = dayFormatter.string(from: startDate)
   let endsOn = dayFormatter.string(from: endDate)
-  let startsAtUtc = startsOn + "T00:00:00Z"
-  let endsAtUtc = endsOn + "T00:00:00Z"
-  let sourceReportKey = "clan_wars:\(startsOn)_\(endsOn)"
+  let startsAt = startsOn + "T00:00:00Z"
+  let endsAt = endsOn + "T00:00:00Z"
 
   return TournamentWindow(
-    sourceReportKey: sourceReportKey,
-    startsOn: startsOn,
-    endsOn: endsOn,
-    startsAtUtc: startsAtUtc,
-    endsAtUtc: endsAtUtc
+    sourceReportKey: "clan_wars:\(startsOn)_\(endsOn)",
+    startsAt: startsAt,
+    endsAt: endsAt
   )
 }
 
-func readMarkdownLines(_ url: URL) throws -> [OCRLine] {
-  let text = try String(contentsOf: url, encoding: .utf8)
-  return text
-    .split(separator: "\n")
-    .map { String($0) }
-    .filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
-    .map {
-      OCRLine(text: $0, confidence: 1.0, boundingBox: [0.0, 0.0, 0.0, 0.0])
-    }
-}
-
-func readImageLines(_ url: URL) throws -> [OCRLine] {
+func readImageTokens(_ url: URL) throws -> [OCRToken] {
   guard let image = NSImage(contentsOf: url) else {
     throw NSError(domain: "ocr", code: 1, userInfo: [NSLocalizedDescriptionKey: "Cannot load image at \(url.path)"])
   }
@@ -255,17 +254,213 @@ func readImageLines(_ url: URL) throws -> [OCRLine] {
 
   let observations = request.results ?? []
   return observations.compactMap { observation in
-    guard let best = observation.topCandidates(1).first else {
+    guard let candidate = observation.topCandidates(1).first else {
       return nil
     }
 
     let box = observation.boundingBox
-    return OCRLine(
-      text: best.string,
-      confidence: Double(best.confidence),
-      boundingBox: [Double(box.minX), Double(box.minY), Double(box.width), Double(box.height)]
+    return OCRToken(
+      text: candidate.string,
+      x: Double(box.minX),
+      y: Double(box.minY),
+      confidence: Double(candidate.confidence)
     )
   }
+}
+
+func readMarkdownTokens(_ url: URL) throws -> [OCRToken] {
+  let text = try String(contentsOf: url, encoding: .utf8)
+  let lines = text
+    .split(separator: "\n")
+    .map { String($0) }
+    .filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+
+  var y = 1.0
+  return lines.map { line in
+    defer { y -= 0.01 }
+    return OCRToken(text: line, x: 0.0, y: y, confidence: 1.0)
+  }
+}
+
+func extractHasPersonalRewards(_ tokens: [OCRToken]) -> Int {
+  let patterns = ["личные награды", "личные", "nuyhbie", "nu4hbie"]
+  for token in tokens {
+    let n = normalized(token.text)
+    if patterns.contains(where: { n.contains($0) }) {
+      return 1
+    }
+  }
+  return 0
+}
+
+func extractTotalsFromImage(_ tokens: [OCRToken]) -> ClanWarsTotals {
+  let oursCandidate = tokens
+    .filter { $0.x >= 0.16 && $0.x <= 0.35 && $0.y > 0.88 }
+    .compactMap { token -> (Double, Int)? in
+      guard let parsed = parseIntClamped(token.text, max: 20_000_000), parsed >= 1_000_000 else {
+        return nil
+      }
+      return (token.y, parsed)
+    }
+    .sorted { $0.0 > $1.0 }
+    .first?.1
+
+  let opponentCandidate = tokens
+    .filter { $0.x >= 0.84 && $0.y > 0.88 }
+    .compactMap { token -> (Double, Int)? in
+      guard let parsed = parseIntClamped(token.text, max: 20_000_000), parsed >= 1_000_000 else {
+        return nil
+      }
+      return (token.y, parsed)
+    }
+    .sorted { $0.0 > $1.0 }
+    .first?.1
+
+  return ClanWarsTotals(mine: oursCandidate, opponent: opponentCandidate)
+}
+
+func extractOpponentClanNameFromImage(_ tokens: [OCRToken]) -> String? {
+  let candidate = tokens
+    .filter { $0.x >= 0.66 && $0.x <= 0.90 && $0.y > 0.88 && containsLetter($0.text) }
+    .sorted { $0.y > $1.y }
+    .first?.text
+
+  guard var clan = candidate else {
+    return nil
+  }
+
+  clan = clan.replacingOccurrences(of: #"\[[^\]]*ур\.?[^\]]*\]"#, with: "", options: [.regularExpression, .caseInsensitive])
+  clan = clan.replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+  clan = clan.trimmingCharacters(in: .whitespacesAndNewlines)
+  return clan.isEmpty ? candidate : clan
+}
+
+func isHeaderOrNoiseName(_ text: String) -> Bool {
+  let n = normalized(text)
+  let patterns = [
+    "турнир", "ход турнира", "клановые", "личные", "награды", "задания", "участники", "рейтинг", "вильне братство", "vs"
+  ]
+  return patterns.contains(where: { n.contains($0) })
+}
+
+func extractOursBreakdownFromImage(_ tokens: [OCRToken]) -> [ClanWarsPlayerBreakdown] {
+  let vsY = tokens
+    .first(where: { normalized($0.text) == "vs" || normalized($0.text).contains(" vs") || normalized($0.text).contains("vs ") })?
+    .y ?? 0.92
+
+  let ranks = tokens
+    .filter { $0.x >= 0.55 && $0.x <= 0.63 && $0.y < vsY }
+    .compactMap { token -> (Double, Int)? in
+      guard let rank = parseInt(token.text), rank >= 1, rank <= 30 else {
+        return nil
+      }
+      return (token.y, rank)
+    }
+    .sorted { $0.0 > $1.0 }
+
+  let names = tokens
+    .filter { $0.x >= 0.31 && $0.x <= 0.56 && $0.y < vsY && $0.y < 0.90 }
+    .filter { containsLetter($0.text) && !isHeaderOrNoiseName($0.text) }
+    .sorted { $0.y > $1.y }
+
+  let points = tokens
+    .filter { $0.x >= 0.17 && $0.x <= 0.31 && $0.y < vsY && $0.y < 0.90 }
+    .compactMap { token -> (Double, Int)? in
+      guard let value = parseInt(token.text), value >= 1_000, value <= 2_500_000 else {
+        return nil
+      }
+      return (token.y, value)
+    }
+    .sorted { $0.0 > $1.0 }
+
+  let count = min(ranks.count, names.count, points.count)
+  if count == 0 {
+    return []
+  }
+
+  var rows: [ClanWarsPlayerBreakdown] = []
+  rows.reserveCapacity(count)
+
+  for index in 0..<count {
+    rows.append(
+      ClanWarsPlayerBreakdown(
+        rank: ranks[index].1,
+        playerNick: names[index].text,
+        points: points[index].1
+      )
+    )
+  }
+
+  return rows
+}
+
+func extractTotalsFromMarkdown(_ text: String) -> ClanWarsTotals {
+  var mine: Int?
+  var opponent: Int?
+
+  for line in text.split(separator: "\n").map(String.init) {
+    let n = normalized(line)
+    if n.contains("очки вильне братство") {
+      mine = parseInt(line)
+    } else if n.contains("очки ") && n.contains("matrix") {
+      opponent = parseInt(line)
+    }
+  }
+
+  return ClanWarsTotals(mine: mine, opponent: opponent)
+}
+
+func extractOpponentClanNameFromMarkdown(_ text: String) -> String? {
+  let pattern = #"\*\*[^*]+\*\*\s+и\s+\*\*([^*]+)\*\*"#
+  guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+    return nil
+  }
+  guard let match = regex.firstMatch(in: text, range: NSRange(location: 0, length: text.utf16.count)) else {
+    return nil
+  }
+  guard let range = Range(match.range(at: 1), in: text) else {
+    return nil
+  }
+  return String(text[range]).trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+func extractOursBreakdownFromMarkdown(_ text: String) -> [ClanWarsPlayerBreakdown] {
+  let lines = text.split(separator: "\n").map(String.init)
+  var inOursSection = false
+  var rows: [ClanWarsPlayerBreakdown] = []
+
+  for line in lines {
+    if line.contains("### **Вільне Братство") {
+      inOursSection = true
+      continue
+    }
+
+    if inOursSection && line.contains("### **") {
+      break
+    }
+
+    guard inOursSection else {
+      continue
+    }
+
+    let pattern = #"^\|\s*(\d+)\s*\|\s*([^|]+?)\s*\|\s*([0-9,\s]+)\s*\|"#
+    guard
+      let regex = try? NSRegularExpression(pattern: pattern),
+      let match = regex.firstMatch(in: line, range: NSRange(location: 0, length: line.utf16.count)),
+      let rankRange = Range(match.range(at: 1), in: line),
+      let nameRange = Range(match.range(at: 2), in: line),
+      let pointsRange = Range(match.range(at: 3), in: line),
+      let rank = Int(line[rankRange]),
+      let points = parseInt(String(line[pointsRange]))
+    else {
+      continue
+    }
+
+    let name = String(line[nameRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+    rows.append(ClanWarsPlayerBreakdown(rank: rank, playerNick: name, points: points))
+  }
+
+  return rows
 }
 
 func sourceType(for fileName: String) -> SourceType? {
@@ -288,75 +483,71 @@ let options = parseOptions()
 let fm = FileManager.default
 let inputURL = URL(fileURLWithPath: options.inputDirectory)
 
-let allFiles = try fm.contentsOfDirectory(at: inputURL, includingPropertiesForKeys: nil)
+let files = try fm.contentsOfDirectory(at: inputURL, includingPropertiesForKeys: nil)
   .sorted { $0.lastPathComponent < $1.lastPathComponent }
 
-var pages: [OCRPageClanWars] = []
+var tournaments: [ClanWarsTournamentImport] = []
 
-for fileURL in allFiles {
+for fileURL in files {
   let fileName = fileURL.lastPathComponent
-  guard let type = sourceType(for: fileName) else {
+  guard let type = sourceType(for: fileName), let window = parseWindow(from: fileName) else {
     continue
   }
 
-  let lines: [OCRLine]
   switch type {
   case .image:
-    lines = try readImageLines(fileURL)
+    let tokens = try readImageTokens(fileURL)
+    let tournament = ClanWarsTournamentImport(
+      sourceFile: fileName,
+      sourceType: .image,
+      sourceReportKey: window.sourceReportKey,
+      startsAt: window.startsAt,
+      endsAt: window.endsAt,
+      hasPersonalRewards: extractHasPersonalRewards(tokens),
+      opponentClanName: extractOpponentClanNameFromImage(tokens),
+      totals: extractTotalsFromImage(tokens),
+      playersOurs: extractOursBreakdownFromImage(tokens)
+    )
+    tournaments.append(tournament)
+
   case .markdown:
-    lines = try readMarkdownLines(fileURL)
+    let text = try String(contentsOf: fileURL, encoding: .utf8)
+    let markdownTokens = try readMarkdownTokens(fileURL)
+    let tournament = ClanWarsTournamentImport(
+      sourceFile: fileName,
+      sourceType: .markdown,
+      sourceReportKey: window.sourceReportKey,
+      startsAt: window.startsAt,
+      endsAt: window.endsAt,
+      hasPersonalRewards: extractHasPersonalRewards(markdownTokens),
+      opponentClanName: extractOpponentClanNameFromMarkdown(text),
+      totals: extractTotalsFromMarkdown(text),
+      playersOurs: extractOursBreakdownFromMarkdown(text)
+    )
+    tournaments.append(tournament)
   }
-
-  let reward = inferRewards(from: lines)
-  let page = OCRPageClanWars(
-    fileName: fileName,
-    sourceType: type,
-    window: parseWindow(from: fileName),
-    rewardInference: reward,
-    lineCount: lines.count,
-    lines: lines
-  )
-  pages.append(page)
 }
 
-let recommendations = pages.compactMap { page -> WindowRecommendation? in
-  guard
-    let window = page.window,
-    page.rewardInference.hasPersonalRewards,
-    page.rewardInference.confidence >= options.minConfidence
-  else {
-    return nil
-  }
+let sortedTournaments = tournaments.sorted { $0.startsAt < $1.startsAt }
 
-  return WindowRecommendation(
-    sourceReportKey: window.sourceReportKey,
-    startsAtUtc: window.startsAtUtc,
-    endsAtUtc: window.endsAtUtc,
-    confidence: page.rewardInference.confidence,
-    evidence: page.rewardInference.evidence,
-    sourceFile: page.fileName
-  )
-}
-
-let report = OCRRunReport(
+let report = CanonicalClanWarsImportReport(
   generatedAt: ISO8601DateFormatter().string(from: Date()),
   inputDirectory: options.inputDirectory,
-  modelName: "vision-v1-page-ocr-clan-wars",
-  pages: pages,
-  recommendedPersonalRewardsWindows: recommendations
+  activity: "clan_wars",
+  tournaments: sortedTournaments
 )
 
 let encoder = JSONEncoder()
 encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
-
 let data = try encoder.encode(report)
 try ensureParentDirectory(for: options.outputPath)
 try data.write(to: URL(fileURLWithPath: options.outputPath))
 
-print("Wrote OCR report: \(options.outputPath)")
-print("Processed pages: \(pages.count)")
-print("Recommended has_personal_rewards windows: \(recommendations.count)")
-for rec in recommendations {
-  let confidence = String(format: "%.2f", rec.confidence)
-  print("- \(rec.startsAtUtc) .. \(rec.endsAtUtc) (file: \(rec.sourceFile), confidence: \(confidence))")
+print("Wrote canonical import report: \(options.outputPath)")
+print("Tournaments parsed: \(sortedTournaments.count)")
+
+let rewards = sortedTournaments.filter { $0.hasPersonalRewards == 1 }
+print("has_personal_rewards=1 windows: \(rewards.count)")
+for window in rewards {
+  print("- \(window.startsAt) .. \(window.endsAt) [\(window.sourceFile)]")
 }

--- a/tool/ocr-clan-results/ocr-clan-results.swift
+++ b/tool/ocr-clan-results/ocr-clan-results.swift
@@ -1,12 +1,12 @@
 #!/usr/bin/env swift
 
 import AppKit
+import Darwin
 import Foundation
 import Vision
 
 enum SourceType: String, Codable {
   case image
-  case markdown
 }
 
 struct ClanWarsTotals: Codable {
@@ -40,8 +40,10 @@ struct CanonicalClanWarsImportReport: Codable {
 }
 
 struct CLIOptions {
-  let inputDirectory: String
+  let imagePath: String
+  let participantsPath: String
   let outputPath: String
+  let maxMineTotalDiffRatio: Double
 }
 
 struct OCRToken {
@@ -57,31 +59,110 @@ struct TournamentWindow {
   let endsAt: String
 }
 
-func parseOptions() -> CLIOptions {
-  var inputDirectory = NSHomeDirectory() + "/Downloads/clanwars"
-  var outputPath = "tool/ocr-clan-results/out/clanwars-canonical-import.json"
+enum CLIError: Error, LocalizedError {
+  case missingRequiredOption(String)
+  case invalidOptionValue(String)
+  case unsupportedImageFile(String)
+  case participantsListEmpty(String)
+  case cannotInferWindowFromFileName(String)
+  case totalsValidationFailed(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .missingRequiredOption(let option):
+      return "Missing required option: \(option)"
+    case .invalidOptionValue(let message):
+      return "Invalid option value: \(message)"
+    case .unsupportedImageFile(let path):
+      return "Unsupported image file extension: \(path)"
+    case .participantsListEmpty(let path):
+      return "Participants list is empty after parsing JSON: \(path)"
+    case .cannotInferWindowFromFileName(let fileName):
+      return "Cannot infer clan wars window from screenshot file name: \(fileName)"
+    case .totalsValidationFailed(let message):
+      return message
+    }
+  }
+}
+
+func printUsage() {
+  let usage = """
+  Usage:
+    swift tool/ocr-clan-results/ocr-clan-results.swift \\
+      --image /absolute/path/to/10.04.25.jpg \\
+      --participants-json /absolute/path/to/clan-members.json \\
+      [--output tool/ocr-clan-results/out/page-ocr-clan-wars.json] \\
+      [--max-mine-total-diff-ratio 0.01]
+
+  Supported participants JSON shapes:
+    - ["Nick1", "Nick2", ...]
+    - { "participants": ["Nick1", ...] }
+    - { "players": [{ "nick": "Nick1" }, ...] }
+  """
+  print(usage)
+}
+
+func parseOptions() throws -> CLIOptions {
+  var imagePath: String?
+  var participantsPath: String?
+  var outputPath = "tool/ocr-clan-results/out/page-ocr-clan-wars.json"
+  var maxMineTotalDiffRatio = 0.01
 
   var index = 1
   while index < CommandLine.arguments.count {
     let arg = CommandLine.arguments[index]
     switch arg {
-    case "--input", "-i":
+    case "--image", "-i":
       index += 1
       if index < CommandLine.arguments.count {
-        inputDirectory = CommandLine.arguments[index]
+        imagePath = CommandLine.arguments[index]
+      }
+    case "--participants-json", "-p":
+      index += 1
+      if index < CommandLine.arguments.count {
+        participantsPath = CommandLine.arguments[index]
       }
     case "--output", "-o":
       index += 1
       if index < CommandLine.arguments.count {
         outputPath = CommandLine.arguments[index]
       }
+    case "--max-mine-total-diff-ratio":
+      index += 1
+      if index < CommandLine.arguments.count {
+        guard let value = Double(CommandLine.arguments[index]), value >= 0 else {
+          throw CLIError.invalidOptionValue("--max-mine-total-diff-ratio must be a non-negative number")
+        }
+        maxMineTotalDiffRatio = value
+      }
+    case "--help", "-h":
+      printUsage()
+      exit(0)
     default:
       break
     }
     index += 1
   }
 
-  return CLIOptions(inputDirectory: inputDirectory, outputPath: outputPath)
+  guard let imagePath else {
+    throw CLIError.missingRequiredOption("--image")
+  }
+
+  guard let participantsPath else {
+    throw CLIError.missingRequiredOption("--participants-json")
+  }
+
+  let lowerPath = imagePath.lowercased()
+  if !(lowerPath.hasSuffix(".jpg") || lowerPath.hasSuffix(".jpeg") || lowerPath.hasSuffix(".png")) {
+    throw CLIError.unsupportedImageFile(imagePath)
+  }
+
+  return CLIOptions(
+    imagePath: imagePath,
+    participantsPath: participantsPath,
+    outputPath: outputPath,
+    maxMineTotalDiffRatio: maxMineTotalDiffRatio
+  )
 }
 
 func normalized(_ value: String) -> String {
@@ -268,20 +349,6 @@ func readImageTokens(_ url: URL) throws -> [OCRToken] {
   }
 }
 
-func readMarkdownTokens(_ url: URL) throws -> [OCRToken] {
-  let text = try String(contentsOf: url, encoding: .utf8)
-  let lines = text
-    .split(separator: "\n")
-    .map { String($0) }
-    .filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
-
-  var y = 1.0
-  return lines.map { line in
-    defer { y -= 0.01 }
-    return OCRToken(text: line, x: 0.0, y: y, confidence: 1.0)
-  }
-}
-
 func extractHasPersonalRewards(_ tokens: [OCRToken]) -> Int {
   let patterns = ["личные награды", "личные", "nuyhbie", "nu4hbie"]
   for token in tokens {
@@ -394,84 +461,248 @@ func extractOursBreakdownFromImage(_ tokens: [OCRToken]) -> [ClanWarsPlayerBreak
   return rows
 }
 
-func extractTotalsFromMarkdown(_ text: String) -> ClanWarsTotals {
-  var mine: Int?
-  var opponent: Int?
+func normalizedForMatch(_ value: String) -> String {
+  let lowered = normalized(value)
+  var folded = ""
+  folded.reserveCapacity(lowered.count)
 
-  for line in text.split(separator: "\n").map(String.init) {
-    let n = normalized(line)
-    if n.contains("очки вильне братство") {
-      mine = parseInt(line)
-    } else if n.contains("очки ") && n.contains("matrix") {
-      opponent = parseInt(line)
+  for scalar in lowered.unicodeScalars {
+    switch scalar {
+    case "а", "a", "@":
+      folded.append("a")
+    case "в", "b", "8":
+      folded.append("b")
+    case "с", "c":
+      folded.append("c")
+    case "е", "e":
+      folded.append("e")
+    case "к", "k":
+      folded.append("k")
+    case "м", "m":
+      folded.append("m")
+    case "н", "h":
+      folded.append("h")
+    case "о", "o", "0":
+      folded.append("o")
+    case "р", "p":
+      folded.append("p")
+    case "т", "t":
+      folded.append("t")
+    case "у", "y":
+      folded.append("y")
+    case "х", "x":
+      folded.append("x")
+    case "и", "n":
+      folded.append("n")
+    case "л", "l":
+      folded.append("l")
+    case "д", "d":
+      folded.append("d")
+    default:
+      if CharacterSet.alphanumerics.contains(scalar) {
+        folded.unicodeScalars.append(scalar)
+      }
     }
   }
 
-  return ClanWarsTotals(mine: mine, opponent: opponent)
+  return folded
 }
 
-func extractOpponentClanNameFromMarkdown(_ text: String) -> String? {
-  let pattern = #"\*\*[^*]+\*\*\s+и\s+\*\*([^*]+)\*\*"#
-  guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
-    return nil
+func levenshteinDistance(_ lhs: String, _ rhs: String) -> Int {
+  if lhs == rhs {
+    return 0
   }
-  guard let match = regex.firstMatch(in: text, range: NSRange(location: 0, length: text.utf16.count)) else {
-    return nil
+
+  let left = Array(lhs)
+  let right = Array(rhs)
+
+  if left.isEmpty {
+    return right.count
   }
-  guard let range = Range(match.range(at: 1), in: text) else {
-    return nil
+
+  if right.isEmpty {
+    return left.count
   }
-  return String(text[range]).trimmingCharacters(in: .whitespacesAndNewlines)
+
+  var previous = Array(0...right.count)
+  var current = Array(repeating: 0, count: right.count + 1)
+
+  for i in 1...left.count {
+    current[0] = i
+    for j in 1...right.count {
+      let cost = left[i - 1] == right[j - 1] ? 0 : 1
+      current[j] = min(
+        previous[j] + 1,
+        current[j - 1] + 1,
+        previous[j - 1] + cost
+      )
+    }
+    swap(&previous, &current)
+  }
+
+  return previous[right.count]
 }
 
-func extractOursBreakdownFromMarkdown(_ text: String) -> [ClanWarsPlayerBreakdown] {
-  let lines = text.split(separator: "\n").map(String.init)
-  var inOursSection = false
-  var rows: [ClanWarsPlayerBreakdown] = []
+func uniquePreservingOrder(_ values: [String]) -> [String] {
+  var seen = Set<String>()
+  var result: [String] = []
+  result.reserveCapacity(values.count)
+  for value in values {
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+      continue
+    }
+    if seen.insert(trimmed).inserted {
+      result.append(trimmed)
+    }
+  }
+  return result
+}
 
-  for line in lines {
-    if line.contains("### **Вільне Братство") {
-      inOursSection = true
+func collectNicknames(from json: Any) -> [String] {
+  if let value = json as? String {
+    return [value]
+  }
+
+  if let array = json as? [Any] {
+    return array.flatMap(collectNicknames)
+  }
+
+  if let object = json as? [String: Any] {
+    var result: [String] = []
+    let collectionKeys = [
+      "participants", "members", "players", "roster", "clanMembers", "clan_members", "list"
+    ]
+    for key in collectionKeys {
+      if let nested = object[key] {
+        result.append(contentsOf: collectNicknames(from: nested))
+      }
+    }
+
+    let nicknameKeys = [
+      "nick", "nickname", "playerNick", "player_nick", "mainNickname", "main_nickname", "name"
+    ]
+    for key in nicknameKeys {
+      if let nickname = object[key] as? String {
+        result.append(nickname)
+      }
+    }
+
+    return result
+  }
+
+  return []
+}
+
+func loadParticipantsList(from path: String) throws -> [String] {
+  let url = URL(fileURLWithPath: path)
+  let data = try Data(contentsOf: url)
+  let parsed = try JSONSerialization.jsonObject(with: data)
+  let names = uniquePreservingOrder(collectNicknames(from: parsed))
+  return names
+}
+
+struct NameCorrection {
+  let rank: Int
+  let from: String
+  let to: String
+  let distance: Int
+}
+
+func autocorrectNicknames(
+  rows: [ClanWarsPlayerBreakdown],
+  members: [String]
+) -> (rows: [ClanWarsPlayerBreakdown], corrections: [NameCorrection]) {
+  guard !rows.isEmpty, !members.isEmpty else {
+    return (rows, [])
+  }
+
+  struct MemberCandidate {
+    let index: Int
+    let name: String
+    let normalized: String
+  }
+
+  let candidates = members.enumerated().map { entry in
+    MemberCandidate(index: entry.offset, name: entry.element, normalized: normalizedForMatch(entry.element))
+  }
+
+  var available = Set(candidates.map(\.index))
+  var assignments: [Int: (member: MemberCandidate, distance: Int)] = [:]
+
+  for (rowIndex, row) in rows.enumerated() {
+    let rowNorm = normalizedForMatch(row.playerNick)
+    guard !rowNorm.isEmpty else {
+      continue
+    }
+    if let exact = candidates.first(where: { available.contains($0.index) && $0.normalized == rowNorm }) {
+      assignments[rowIndex] = (exact, 0)
+      available.remove(exact.index)
+    }
+  }
+
+  for (rowIndex, row) in rows.enumerated() where assignments[rowIndex] == nil {
+    let rowNorm = normalizedForMatch(row.playerNick)
+    guard !rowNorm.isEmpty else {
       continue
     }
 
-    if inOursSection && line.contains("### **") {
-      break
+    var best: (member: MemberCandidate, distance: Int, ratio: Double)?
+
+    for candidate in candidates where available.contains(candidate.index) {
+      let distance = levenshteinDistance(rowNorm, candidate.normalized)
+      let base = max(rowNorm.count, candidate.normalized.count, 1)
+      let ratio = Double(distance) / Double(base)
+
+      if let current = best {
+        if ratio < current.ratio
+          || (ratio == current.ratio && distance < current.distance)
+          || (ratio == current.ratio && distance == current.distance && candidate.name < current.member.name)
+        {
+          best = (candidate, distance, ratio)
+        }
+      } else {
+        best = (candidate, distance, ratio)
+      }
     }
 
-    guard inOursSection else {
+    if let best {
+      assignments[rowIndex] = (best.member, best.distance)
+      available.remove(best.member.index)
+    }
+  }
+
+  var correctedRows: [ClanWarsPlayerBreakdown] = []
+  correctedRows.reserveCapacity(rows.count)
+
+  var corrections: [NameCorrection] = []
+
+  for (rowIndex, row) in rows.enumerated() {
+    guard let assignment = assignments[rowIndex] else {
+      correctedRows.append(row)
       continue
     }
 
-    let pattern = #"^\|\s*(\d+)\s*\|\s*([^|]+?)\s*\|\s*([0-9,\s]+)\s*\|"#
-    guard
-      let regex = try? NSRegularExpression(pattern: pattern),
-      let match = regex.firstMatch(in: line, range: NSRange(location: 0, length: line.utf16.count)),
-      let rankRange = Range(match.range(at: 1), in: line),
-      let nameRange = Range(match.range(at: 2), in: line),
-      let pointsRange = Range(match.range(at: 3), in: line),
-      let rank = Int(line[rankRange]),
-      let points = parseInt(String(line[pointsRange]))
-    else {
-      continue
+    let corrected = ClanWarsPlayerBreakdown(
+      rank: row.rank,
+      playerNick: assignment.member.name,
+      points: row.points
+    )
+    correctedRows.append(corrected)
+
+    if row.playerNick != assignment.member.name {
+      corrections.append(
+        NameCorrection(
+          rank: row.rank,
+          from: row.playerNick,
+          to: assignment.member.name,
+          distance: assignment.distance
+        )
+      )
     }
-
-    let name = String(line[nameRange]).trimmingCharacters(in: .whitespacesAndNewlines)
-    rows.append(ClanWarsPlayerBreakdown(rank: rank, playerNick: name, points: points))
   }
 
-  return rows
-}
-
-func sourceType(for fileName: String) -> SourceType? {
-  let lower = fileName.lowercased()
-  if lower.hasSuffix(".jpg") || lower.hasSuffix(".jpeg") || lower.hasSuffix(".png") {
-    return .image
-  }
-  if lower.hasSuffix(".md") || lower.hasSuffix(".txt") {
-    return .markdown
-  }
-  return nil
+  return (correctedRows, corrections)
 }
 
 func ensureParentDirectory(for path: String) throws {
@@ -479,75 +710,103 @@ func ensureParentDirectory(for path: String) throws {
   try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
 }
 
-let options = parseOptions()
-let fm = FileManager.default
-let inputURL = URL(fileURLWithPath: options.inputDirectory)
-
-let files = try fm.contentsOfDirectory(at: inputURL, includingPropertiesForKeys: nil)
-  .sorted { $0.lastPathComponent < $1.lastPathComponent }
-
-var tournaments: [ClanWarsTournamentImport] = []
-
-for fileURL in files {
-  let fileName = fileURL.lastPathComponent
-  guard let type = sourceType(for: fileName), let window = parseWindow(from: fileName) else {
-    continue
+func validateMineTotal(
+  tournament: ClanWarsTournamentImport,
+  maxDiffRatio: Double
+) throws {
+  guard let mineTotal = tournament.totals.mine, mineTotal > 0 else {
+    throw CLIError.totalsValidationFailed(
+      "OCR validation failed: cannot read valid totals.mine for \(tournament.sourceFile)"
+    )
   }
 
-  switch type {
-  case .image:
-    let tokens = try readImageTokens(fileURL)
-    let tournament = ClanWarsTournamentImport(
-      sourceFile: fileName,
-      sourceType: .image,
-      sourceReportKey: window.sourceReportKey,
-      startsAt: window.startsAt,
-      endsAt: window.endsAt,
-      hasPersonalRewards: extractHasPersonalRewards(tokens),
-      opponentClanName: extractOpponentClanNameFromImage(tokens),
-      totals: extractTotalsFromImage(tokens),
-      playersOurs: extractOursBreakdownFromImage(tokens)
-    )
-    tournaments.append(tournament)
+  let oursSum = tournament.playersOurs.reduce(0) { $0 + $1.points }
+  let absoluteDiff = abs(oursSum - mineTotal)
+  let diffRatio = Double(absoluteDiff) / Double(max(mineTotal, 1))
 
-  case .markdown:
-    let text = try String(contentsOf: fileURL, encoding: .utf8)
-    let markdownTokens = try readMarkdownTokens(fileURL)
-    let tournament = ClanWarsTournamentImport(
-      sourceFile: fileName,
-      sourceType: .markdown,
-      sourceReportKey: window.sourceReportKey,
-      startsAt: window.startsAt,
-      endsAt: window.endsAt,
-      hasPersonalRewards: extractHasPersonalRewards(markdownTokens),
-      opponentClanName: extractOpponentClanNameFromMarkdown(text),
-      totals: extractTotalsFromMarkdown(text),
-      playersOurs: extractOursBreakdownFromMarkdown(text)
+  if diffRatio > maxDiffRatio {
+    let percent = diffRatio * 100.0
+    throw CLIError.totalsValidationFailed(
+      String(
+        format: "OCR validation failed: oursSum=%d, totals.mine=%d, diff=%d (%.2f%%), threshold=%.2f%%",
+        oursSum,
+        mineTotal,
+        absoluteDiff,
+        percent,
+        maxDiffRatio * 100.0
+      )
     )
-    tournaments.append(tournament)
   }
 }
 
-let sortedTournaments = tournaments.sorted { $0.startsAt < $1.startsAt }
+do {
+  let options = try parseOptions()
+  let imageURL = URL(fileURLWithPath: options.imagePath)
+  let fileName = imageURL.lastPathComponent
 
-let report = CanonicalClanWarsImportReport(
-  generatedAt: ISO8601DateFormatter().string(from: Date()),
-  inputDirectory: options.inputDirectory,
-  activity: "clan_wars",
-  tournaments: sortedTournaments
-)
+  guard let window = parseWindow(from: fileName) else {
+    throw CLIError.cannotInferWindowFromFileName(fileName)
+  }
 
-let encoder = JSONEncoder()
-encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
-let data = try encoder.encode(report)
-try ensureParentDirectory(for: options.outputPath)
-try data.write(to: URL(fileURLWithPath: options.outputPath))
+  let participants = try loadParticipantsList(from: options.participantsPath)
+  guard !participants.isEmpty else {
+    throw CLIError.participantsListEmpty(options.participantsPath)
+  }
 
-print("Wrote canonical import report: \(options.outputPath)")
-print("Tournaments parsed: \(sortedTournaments.count)")
+  let tokens = try readImageTokens(imageURL)
+  let rawRows = extractOursBreakdownFromImage(tokens)
+  let correctionResult = autocorrectNicknames(rows: rawRows, members: participants)
 
-let rewards = sortedTournaments.filter { $0.hasPersonalRewards == 1 }
-print("has_personal_rewards=1 windows: \(rewards.count)")
-for window in rewards {
-  print("- \(window.startsAt) .. \(window.endsAt) [\(window.sourceFile)]")
+  let tournament = ClanWarsTournamentImport(
+    sourceFile: fileName,
+    sourceType: .image,
+    sourceReportKey: window.sourceReportKey,
+    startsAt: window.startsAt,
+    endsAt: window.endsAt,
+    hasPersonalRewards: extractHasPersonalRewards(tokens),
+    opponentClanName: extractOpponentClanNameFromImage(tokens),
+    totals: extractTotalsFromImage(tokens),
+    playersOurs: correctionResult.rows
+  )
+
+  let report = CanonicalClanWarsImportReport(
+    generatedAt: ISO8601DateFormatter().string(from: Date()),
+    inputDirectory: imageURL.deletingLastPathComponent().path,
+    activity: "clan_wars",
+    tournaments: [tournament]
+  )
+
+  let encoder = JSONEncoder()
+  encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+  let data = try encoder.encode(report)
+  try ensureParentDirectory(for: options.outputPath)
+  try data.write(to: URL(fileURLWithPath: options.outputPath))
+
+  print("Wrote canonical import report: \(options.outputPath)")
+  print("Screenshot: \(fileName)")
+  print("Participants loaded: \(participants.count)")
+  print("Players detected (ours): \(tournament.playersOurs.count)")
+
+  if correctionResult.corrections.isEmpty {
+    print("Nickname auto-corrections: 0")
+  } else {
+    print("Nickname auto-corrections: \(correctionResult.corrections.count)")
+    for correction in correctionResult.corrections {
+      print("  #\(correction.rank): '\(correction.from)' -> '\(correction.to)' (distance=\(correction.distance))")
+    }
+  }
+
+  do {
+    try validateMineTotal(tournament: tournament, maxDiffRatio: options.maxMineTotalDiffRatio)
+    let oursSum = tournament.playersOurs.reduce(0) { $0 + $1.points }
+    print("Mine total validation: OK (\(oursSum) vs \(tournament.totals.mine ?? 0))")
+  } catch {
+    fputs("ERROR: \(error.localizedDescription)\n", stderr)
+    exit(2)
+  }
+} catch {
+  fputs("ERROR: \(error.localizedDescription)\n", stderr)
+  fputs("\n", stderr)
+  printUsage()
+  exit(1)
 }

--- a/tool/ocr-clan-results/ocr-clan-results.swift
+++ b/tool/ocr-clan-results/ocr-clan-results.swift
@@ -1,0 +1,362 @@
+#!/usr/bin/env swift
+
+import AppKit
+import Foundation
+import Vision
+
+enum SourceType: String, Codable {
+  case image
+  case markdown
+}
+
+struct OCRLine: Codable {
+  let text: String
+  let confidence: Double
+  let boundingBox: [Double]
+}
+
+struct TournamentWindow: Codable {
+  let sourceReportKey: String
+  let startsOn: String
+  let endsOn: String
+  let startsAtUtc: String
+  let endsAtUtc: String
+}
+
+struct RewardInference: Codable {
+  let hasPersonalRewards: Bool
+  let confidence: Double
+  let decision: String
+  let evidence: [String]
+}
+
+struct OCRPageClanWars: Codable {
+  let fileName: String
+  let sourceType: SourceType
+  let window: TournamentWindow?
+  let rewardInference: RewardInference
+  let lineCount: Int
+  let lines: [OCRLine]
+}
+
+struct WindowRecommendation: Codable {
+  let sourceReportKey: String
+  let startsAtUtc: String
+  let endsAtUtc: String
+  let confidence: Double
+  let evidence: [String]
+  let sourceFile: String
+}
+
+struct OCRRunReport: Codable {
+  let generatedAt: String
+  let inputDirectory: String
+  let modelName: String
+  let pages: [OCRPageClanWars]
+  let recommendedPersonalRewardsWindows: [WindowRecommendation]
+}
+
+struct CLIOptions {
+  let inputDirectory: String
+  let outputPath: String
+  let minConfidence: Double
+}
+
+func parseOptions() -> CLIOptions {
+  var inputDirectory = NSHomeDirectory() + "/Downloads/clanwars"
+  var outputPath = "tool/ocr-clan-results/out/clanwars-ocr-report.json"
+  var minConfidence = 0.8
+
+  var index = 1
+  while index < CommandLine.arguments.count {
+    let arg = CommandLine.arguments[index]
+    switch arg {
+    case "--input", "-i":
+      index += 1
+      if index < CommandLine.arguments.count {
+        inputDirectory = CommandLine.arguments[index]
+      }
+    case "--output", "-o":
+      index += 1
+      if index < CommandLine.arguments.count {
+        outputPath = CommandLine.arguments[index]
+      }
+    case "--min-confidence":
+      index += 1
+      if index < CommandLine.arguments.count, let value = Double(CommandLine.arguments[index]) {
+        minConfidence = value
+      }
+    default:
+      break
+    }
+    index += 1
+  }
+
+  return CLIOptions(inputDirectory: inputDirectory, outputPath: outputPath, minConfidence: minConfidence)
+}
+
+func normalized(_ value: String) -> String {
+  let lowered = value.lowercased()
+  let mapped = lowered.replacingOccurrences(of: "ё", with: "е")
+  let collapsed = mapped.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+  return collapsed.trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+func inferRewards(from lines: [OCRLine]) -> RewardInference {
+  let normalizedLines = lines.map { normalized($0.text) }
+
+  let positivePatterns = [
+    "личные награды",
+    "личные",
+    "лиичные",
+    "nuyhbie",
+    "nu4hbie",
+    "личн"
+  ]
+
+  var evidence: [String] = []
+  var topConfidence = 0.0
+
+  for (idx, line) in normalizedLines.enumerated() {
+    if positivePatterns.contains(where: { line.contains($0) }) {
+      evidence.append(lines[idx].text)
+      topConfidence = max(topConfidence, lines[idx].confidence)
+    }
+  }
+
+  if !evidence.isEmpty {
+    return RewardInference(
+      hasPersonalRewards: true,
+      confidence: max(0.8, topConfidence),
+      decision: "confirmed_by_ocr_marker",
+      evidence: Array(evidence.prefix(5))
+    )
+  }
+
+  return RewardInference(
+    hasPersonalRewards: false,
+    confidence: 0.6,
+    decision: "marker_not_found",
+    evidence: []
+  )
+}
+
+func parseCaptureDate(from fileName: String) -> Date? {
+  let pattern = #"^(\d{2})\.(\d{2})\.(\d{2})"#
+  guard
+    let regex = try? NSRegularExpression(pattern: pattern),
+    let match = regex.firstMatch(in: fileName, range: NSRange(location: 0, length: fileName.utf16.count)),
+    let dayRange = Range(match.range(at: 1), in: fileName),
+    let monthRange = Range(match.range(at: 2), in: fileName),
+    let yearRange = Range(match.range(at: 3), in: fileName),
+    let day = Int(fileName[dayRange]),
+    let month = Int(fileName[monthRange]),
+    let yearShort = Int(fileName[yearRange])
+  else {
+    return nil
+  }
+
+  let year = 2000 + yearShort
+  var comps = DateComponents()
+  comps.year = year
+  comps.month = month
+  comps.day = day
+  comps.hour = 0
+  comps.minute = 0
+  comps.second = 0
+  comps.timeZone = TimeZone(secondsFromGMT: 0)
+
+  let calendar = Calendar(identifier: .gregorian)
+  return calendar.date(from: comps)
+}
+
+func parseWindow(from fileName: String) -> TournamentWindow? {
+  guard let captureDate = parseCaptureDate(from: fileName) else {
+    return nil
+  }
+
+  let calendar = Calendar(identifier: .gregorian)
+  var anchorComps = DateComponents()
+  anchorComps.year = 2025
+  anchorComps.month = 3
+  anchorComps.day = 25
+  anchorComps.hour = 0
+  anchorComps.minute = 0
+  anchorComps.second = 0
+  anchorComps.timeZone = TimeZone(secondsFromGMT: 0)
+  guard let anchorStart = calendar.date(from: anchorComps) else {
+    return nil
+  }
+
+  let biweeklySeconds = 14 * 24 * 60 * 60
+  let windowSpanSeconds = 2 * 24 * 60 * 60
+  let deltaSeconds = Int(captureDate.timeIntervalSince(anchorStart))
+  let cycles = max(0, deltaSeconds / biweeklySeconds)
+
+  guard
+    let startDate = calendar.date(byAdding: .second, value: cycles * biweeklySeconds, to: anchorStart),
+    let endDate = calendar.date(byAdding: .second, value: windowSpanSeconds, to: startDate)
+  else {
+    return nil
+  }
+
+  if captureDate < startDate || captureDate > endDate {
+    return nil
+  }
+
+  let dayFormatter = DateFormatter()
+  dayFormatter.calendar = calendar
+  dayFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+  dayFormatter.dateFormat = "yyyy-MM-dd"
+
+  let startsOn = dayFormatter.string(from: startDate)
+  let endsOn = dayFormatter.string(from: endDate)
+  let startsAtUtc = startsOn + "T00:00:00Z"
+  let endsAtUtc = endsOn + "T00:00:00Z"
+  let sourceReportKey = "clan_wars:\(startsOn)_\(endsOn)"
+
+  return TournamentWindow(
+    sourceReportKey: sourceReportKey,
+    startsOn: startsOn,
+    endsOn: endsOn,
+    startsAtUtc: startsAtUtc,
+    endsAtUtc: endsAtUtc
+  )
+}
+
+func readMarkdownLines(_ url: URL) throws -> [OCRLine] {
+  let text = try String(contentsOf: url, encoding: .utf8)
+  return text
+    .split(separator: "\n")
+    .map { String($0) }
+    .filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+    .map {
+      OCRLine(text: $0, confidence: 1.0, boundingBox: [0.0, 0.0, 0.0, 0.0])
+    }
+}
+
+func readImageLines(_ url: URL) throws -> [OCRLine] {
+  guard let image = NSImage(contentsOf: url) else {
+    throw NSError(domain: "ocr", code: 1, userInfo: [NSLocalizedDescriptionKey: "Cannot load image at \(url.path)"])
+  }
+
+  var rect = NSRect(origin: .zero, size: image.size)
+  guard let cgImage = image.cgImage(forProposedRect: &rect, context: nil, hints: nil) else {
+    throw NSError(domain: "ocr", code: 2, userInfo: [NSLocalizedDescriptionKey: "Cannot create CGImage for \(url.path)"])
+  }
+
+  let request = VNRecognizeTextRequest()
+  request.recognitionLevel = .accurate
+  request.usesLanguageCorrection = true
+  request.recognitionLanguages = ["ru-RU", "uk-UA", "en-US"]
+
+  let handler = VNImageRequestHandler(cgImage: cgImage)
+  try handler.perform([request])
+
+  let observations = request.results ?? []
+  return observations.compactMap { observation in
+    guard let best = observation.topCandidates(1).first else {
+      return nil
+    }
+
+    let box = observation.boundingBox
+    return OCRLine(
+      text: best.string,
+      confidence: Double(best.confidence),
+      boundingBox: [Double(box.minX), Double(box.minY), Double(box.width), Double(box.height)]
+    )
+  }
+}
+
+func sourceType(for fileName: String) -> SourceType? {
+  let lower = fileName.lowercased()
+  if lower.hasSuffix(".jpg") || lower.hasSuffix(".jpeg") || lower.hasSuffix(".png") {
+    return .image
+  }
+  if lower.hasSuffix(".md") || lower.hasSuffix(".txt") {
+    return .markdown
+  }
+  return nil
+}
+
+func ensureParentDirectory(for path: String) throws {
+  let parent = URL(fileURLWithPath: path).deletingLastPathComponent()
+  try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+}
+
+let options = parseOptions()
+let fm = FileManager.default
+let inputURL = URL(fileURLWithPath: options.inputDirectory)
+
+let allFiles = try fm.contentsOfDirectory(at: inputURL, includingPropertiesForKeys: nil)
+  .sorted { $0.lastPathComponent < $1.lastPathComponent }
+
+var pages: [OCRPageClanWars] = []
+
+for fileURL in allFiles {
+  let fileName = fileURL.lastPathComponent
+  guard let type = sourceType(for: fileName) else {
+    continue
+  }
+
+  let lines: [OCRLine]
+  switch type {
+  case .image:
+    lines = try readImageLines(fileURL)
+  case .markdown:
+    lines = try readMarkdownLines(fileURL)
+  }
+
+  let reward = inferRewards(from: lines)
+  let page = OCRPageClanWars(
+    fileName: fileName,
+    sourceType: type,
+    window: parseWindow(from: fileName),
+    rewardInference: reward,
+    lineCount: lines.count,
+    lines: lines
+  )
+  pages.append(page)
+}
+
+let recommendations = pages.compactMap { page -> WindowRecommendation? in
+  guard
+    let window = page.window,
+    page.rewardInference.hasPersonalRewards,
+    page.rewardInference.confidence >= options.minConfidence
+  else {
+    return nil
+  }
+
+  return WindowRecommendation(
+    sourceReportKey: window.sourceReportKey,
+    startsAtUtc: window.startsAtUtc,
+    endsAtUtc: window.endsAtUtc,
+    confidence: page.rewardInference.confidence,
+    evidence: page.rewardInference.evidence,
+    sourceFile: page.fileName
+  )
+}
+
+let report = OCRRunReport(
+  generatedAt: ISO8601DateFormatter().string(from: Date()),
+  inputDirectory: options.inputDirectory,
+  modelName: "vision-v1-page-ocr-clan-wars",
+  pages: pages,
+  recommendedPersonalRewardsWindows: recommendations
+)
+
+let encoder = JSONEncoder()
+encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+
+let data = try encoder.encode(report)
+try ensureParentDirectory(for: options.outputPath)
+try data.write(to: URL(fileURLWithPath: options.outputPath))
+
+print("Wrote OCR report: \(options.outputPath)")
+print("Processed pages: \(pages.count)")
+print("Recommended has_personal_rewards windows: \(recommendations.count)")
+for rec in recommendations {
+  let confidence = String(format: "%.2f", rec.confidence)
+  print("- \(rec.startsAtUtc) .. \(rec.endsAtUtc) (file: \(rec.sourceFile), confidence: \(confidence))")
+}

--- a/tool/ocr-clan-results/out/.gitignore
+++ b/tool/ocr-clan-results/out/.gitignore
@@ -1,0 +1,2 @@
+*.json
+!.gitignore

--- a/tool/ocr-clan-results/render-import-sql.swift
+++ b/tool/ocr-clan-results/render-import-sql.swift
@@ -1,0 +1,100 @@
+#!/usr/bin/env swift
+
+import Foundation
+
+struct ClanWarsTotals: Codable {
+  let mine: Int?
+  let opponent: Int?
+}
+
+struct ClanWarsPlayerBreakdown: Codable {
+  let rank: Int
+  let playerNick: String
+  let points: Int
+}
+
+struct ClanWarsTournamentImport: Codable {
+  let sourceFile: String
+  let sourceType: String
+  let sourceReportKey: String
+  let startsAt: String
+  let endsAt: String
+  let hasPersonalRewards: Int
+  let opponentClanName: String?
+  let totals: ClanWarsTotals
+  let playersOurs: [ClanWarsPlayerBreakdown]
+}
+
+struct CanonicalClanWarsImportReport: Codable {
+  let generatedAt: String
+  let inputDirectory: String
+  let activity: String
+  let tournaments: [ClanWarsTournamentImport]
+}
+
+func sqlString(_ value: String?) -> String {
+  guard let value else { return "NULL" }
+  let escaped = value.replacingOccurrences(of: "'", with: "''")
+  return "'\(escaped)'"
+}
+
+func sqlInt(_ value: Int?) -> String {
+  value.map(String.init) ?? "NULL"
+}
+
+let inputPath = CommandLine.arguments.count > 1
+  ? CommandLine.arguments[1]
+  : "tool/ocr-clan-results/out/clanwars-canonical-import.json"
+let outputPath = CommandLine.arguments.count > 2
+  ? CommandLine.arguments[2]
+  : "tool/ocr-clan-results/out/clanwars-canonical-import.sql"
+
+let data = try Data(contentsOf: URL(fileURLWithPath: inputPath))
+let report = try JSONDecoder().decode(CanonicalClanWarsImportReport.self, from: data)
+
+var sql: [String] = []
+sql.append("-- Generated from \(inputPath)")
+sql.append("DROP TABLE IF EXISTS _cw_import;")
+sql.append("DROP TABLE IF EXISTS _cw_import_players;")
+sql.append("")
+sql.append("CREATE TABLE _cw_import (")
+sql.append("  source_report_key TEXT NOT NULL,")
+sql.append("  starts_at TEXT NOT NULL,")
+sql.append("  ends_at TEXT NOT NULL,")
+sql.append("  has_personal_rewards INTEGER NOT NULL,")
+sql.append("  opponent_clan_name TEXT,")
+sql.append("  total_mine INTEGER,")
+sql.append("  total_opponent INTEGER,")
+sql.append("  source_file TEXT NOT NULL")
+sql.append(");")
+sql.append("")
+sql.append("CREATE TABLE _cw_import_players (")
+sql.append("  source_report_key TEXT NOT NULL,")
+sql.append("  rank INTEGER NOT NULL,")
+sql.append("  player_nick TEXT NOT NULL,")
+sql.append("  points INTEGER NOT NULL")
+sql.append(");")
+sql.append("")
+
+for tournament in report.tournaments {
+  sql.append(
+    "INSERT INTO _cw_import (source_report_key, starts_at, ends_at, has_personal_rewards, opponent_clan_name, total_mine, total_opponent, source_file) VALUES (\(sqlString(tournament.sourceReportKey)), \(sqlString(tournament.startsAt)), \(sqlString(tournament.endsAt)), \(tournament.hasPersonalRewards), \(sqlString(tournament.opponentClanName)), \(sqlInt(tournament.totals.mine)), \(sqlInt(tournament.totals.opponent)), \(sqlString(tournament.sourceFile)));"
+  )
+}
+
+sql.append("")
+
+for tournament in report.tournaments {
+  for player in tournament.playersOurs {
+    sql.append(
+      "INSERT INTO _cw_import_players (source_report_key, rank, player_nick, points) VALUES (\(sqlString(tournament.sourceReportKey)), \(player.rank), \(sqlString(player.playerNick)), \(player.points));"
+    )
+  }
+}
+
+let output = sql.joined(separator: "\n") + "\n"
+try FileManager.default.createDirectory(at: URL(fileURLWithPath: outputPath).deletingLastPathComponent(), withIntermediateDirectories: true)
+try output.write(to: URL(fileURLWithPath: outputPath), atomically: true, encoding: .utf8)
+
+print("Wrote SQL: \(outputPath)")
+print("Tournaments: \(report.tournaments.count)")

--- a/tool/ocr-clan-results/schema/page-ocr-clan-wars.schema.json
+++ b/tool/ocr-clan-results/schema/page-ocr-clan-wars.schema.json
@@ -17,7 +17,7 @@
     "sourceFile": { "type": "string" },
     "sourceType": {
       "type": "string",
-      "enum": ["image", "markdown"]
+      "enum": ["image"]
     },
     "sourceReportKey": {
       "type": "string",

--- a/tool/ocr-clan-results/schema/page-ocr-clan-wars.schema.json
+++ b/tool/ocr-clan-results/schema/page-ocr-clan-wars.schema.json
@@ -1,109 +1,61 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://vibr-clan.org/schema/page-ocr-clan-wars.schema.json",
-  "title": "Page OCR Clan Wars",
+  "$id": "https://vibr-clan.org/schema/clan-wars-tournament-import.schema.json",
+  "title": "Clan Wars Tournament Import",
   "type": "object",
   "required": [
-    "fileName",
+    "sourceFile",
     "sourceType",
-    "rewardInference",
-    "lineCount",
-    "lines"
+    "sourceReportKey",
+    "startsAt",
+    "endsAt",
+    "hasPersonalRewards",
+    "totals",
+    "playersOurs"
   ],
   "properties": {
-    "fileName": {
-      "type": "string",
-      "description": "Input asset file name (image or markdown)."
-    },
+    "sourceFile": { "type": "string" },
     "sourceType": {
       "type": "string",
       "enum": ["image", "markdown"]
     },
-    "window": {
-      "type": ["object", "null"],
-      "required": [
-        "sourceReportKey",
-        "startsOn",
-        "endsOn",
-        "startsAtUtc",
-        "endsAtUtc"
-      ],
-      "properties": {
-        "sourceReportKey": {
-          "type": "string",
-          "pattern": "^clan_wars:[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{4}-[0-9]{2}-[0-9]{2}$"
-        },
-        "startsOn": {
-          "type": "string",
-          "format": "date"
-        },
-        "endsOn": {
-          "type": "string",
-          "format": "date"
-        },
-        "startsAtUtc": {
-          "type": "string",
-          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T00:00:00Z$"
-        },
-        "endsAtUtc": {
-          "type": "string",
-          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T00:00:00Z$"
-        }
-      },
-      "additionalProperties": false
+    "sourceReportKey": {
+      "type": "string",
+      "pattern": "^clan_wars:[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{4}-[0-9]{2}-[0-9]{2}$"
     },
-    "rewardInference": {
-      "type": "object",
-      "required": ["hasPersonalRewards", "confidence", "decision", "evidence"],
-      "properties": {
-        "hasPersonalRewards": {
-          "type": "boolean"
-        },
-        "confidence": {
-          "type": "number",
-          "minimum": 0,
-          "maximum": 1
-        },
-        "decision": {
-          "type": "string",
-          "enum": ["confirmed_by_ocr_marker", "marker_not_found"]
-        },
-        "evidence": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "additionalProperties": false
+    "startsAt": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T00:00:00Z$"
     },
-    "lineCount": {
+    "endsAt": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T00:00:00Z$"
+    },
+    "hasPersonalRewards": {
       "type": "integer",
-      "minimum": 0
+      "enum": [0, 1]
     },
-    "lines": {
+    "opponentClanName": {
+      "type": ["string", "null"]
+    },
+    "totals": {
+      "type": "object",
+      "required": ["mine", "opponent"],
+      "properties": {
+        "mine": { "type": ["integer", "null"], "minimum": 0 },
+        "opponent": { "type": ["integer", "null"], "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "playersOurs": {
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["text", "confidence", "boundingBox"],
+        "required": ["rank", "playerNick", "points"],
         "properties": {
-          "text": {
-            "type": "string"
-          },
-          "confidence": {
-            "type": "number",
-            "minimum": 0,
-            "maximum": 1
-          },
-          "boundingBox": {
-            "type": "array",
-            "description": "Vision normalized rectangle [x, y, width, height].",
-            "items": {
-              "type": "number"
-            },
-            "minItems": 4,
-            "maxItems": 4
-          }
+          "rank": { "type": "integer", "minimum": 1, "maximum": 30 },
+          "playerNick": { "type": "string" },
+          "points": { "type": "integer", "minimum": 0 }
         },
         "additionalProperties": false
       }

--- a/tool/ocr-clan-results/schema/page-ocr-clan-wars.schema.json
+++ b/tool/ocr-clan-results/schema/page-ocr-clan-wars.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vibr-clan.org/schema/page-ocr-clan-wars.schema.json",
+  "title": "Page OCR Clan Wars",
+  "type": "object",
+  "required": [
+    "fileName",
+    "sourceType",
+    "rewardInference",
+    "lineCount",
+    "lines"
+  ],
+  "properties": {
+    "fileName": {
+      "type": "string",
+      "description": "Input asset file name (image or markdown)."
+    },
+    "sourceType": {
+      "type": "string",
+      "enum": ["image", "markdown"]
+    },
+    "window": {
+      "type": ["object", "null"],
+      "required": [
+        "sourceReportKey",
+        "startsOn",
+        "endsOn",
+        "startsAtUtc",
+        "endsAtUtc"
+      ],
+      "properties": {
+        "sourceReportKey": {
+          "type": "string",
+          "pattern": "^clan_wars:[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+        },
+        "startsOn": {
+          "type": "string",
+          "format": "date"
+        },
+        "endsOn": {
+          "type": "string",
+          "format": "date"
+        },
+        "startsAtUtc": {
+          "type": "string",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T00:00:00Z$"
+        },
+        "endsAtUtc": {
+          "type": "string",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T00:00:00Z$"
+        }
+      },
+      "additionalProperties": false
+    },
+    "rewardInference": {
+      "type": "object",
+      "required": ["hasPersonalRewards", "confidence", "decision", "evidence"],
+      "properties": {
+        "hasPersonalRewards": {
+          "type": "boolean"
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "decision": {
+          "type": "string",
+          "enum": ["confirmed_by_ocr_marker", "marker_not_found"]
+        },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "lineCount": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "lines": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["text", "confidence", "boundingBox"],
+        "properties": {
+          "text": {
+            "type": "string"
+          },
+          "confidence": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "boundingBox": {
+            "type": "array",
+            "description": "Vision normalized rectangle [x, y, width, height].",
+            "items": {
+              "type": "number"
+            },
+            "minItems": 4,
+            "maxItems": 4
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/tool/ocr-clan-results/schema/run-report.schema.json
+++ b/tool/ocr-clan-results/schema/run-report.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vibr-clan.org/schema/ocr-clan-wars-run-report.schema.json",
+  "title": "OCR Clan Wars Run Report",
+  "type": "object",
+  "required": [
+    "generatedAt",
+    "inputDirectory",
+    "modelName",
+    "pages",
+    "recommendedPersonalRewardsWindows"
+  ],
+  "properties": {
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "inputDirectory": {
+      "type": "string"
+    },
+    "modelName": {
+      "type": "string"
+    },
+    "pages": {
+      "type": "array",
+      "items": {
+        "$ref": "./page-ocr-clan-wars.schema.json"
+      }
+    },
+    "recommendedPersonalRewardsWindows": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "sourceReportKey",
+          "startsAtUtc",
+          "endsAtUtc",
+          "confidence",
+          "evidence",
+          "sourceFile"
+        ],
+        "properties": {
+          "sourceReportKey": { "type": "string" },
+          "startsAtUtc": { "type": "string" },
+          "endsAtUtc": { "type": "string" },
+          "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+          "evidence": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "sourceFile": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/tool/ocr-clan-results/schema/run-report.schema.json
+++ b/tool/ocr-clan-results/schema/run-report.schema.json
@@ -1,57 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://vibr-clan.org/schema/ocr-clan-wars-run-report.schema.json",
-  "title": "OCR Clan Wars Run Report",
+  "$id": "https://vibr-clan.org/schema/clan-wars-import-report.schema.json",
+  "title": "Clan Wars OCR Canonical Import Report",
   "type": "object",
-  "required": [
-    "generatedAt",
-    "inputDirectory",
-    "modelName",
-    "pages",
-    "recommendedPersonalRewardsWindows"
-  ],
+  "required": ["generatedAt", "inputDirectory", "activity", "tournaments"],
   "properties": {
-    "generatedAt": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "inputDirectory": {
-      "type": "string"
-    },
-    "modelName": {
-      "type": "string"
-    },
-    "pages": {
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "inputDirectory": { "type": "string" },
+    "activity": { "type": "string", "const": "clan_wars" },
+    "tournaments": {
       "type": "array",
-      "items": {
-        "$ref": "./page-ocr-clan-wars.schema.json"
-      }
-    },
-    "recommendedPersonalRewardsWindows": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "sourceReportKey",
-          "startsAtUtc",
-          "endsAtUtc",
-          "confidence",
-          "evidence",
-          "sourceFile"
-        ],
-        "properties": {
-          "sourceReportKey": { "type": "string" },
-          "startsAtUtc": { "type": "string" },
-          "endsAtUtc": { "type": "string" },
-          "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
-          "evidence": {
-            "type": "array",
-            "items": { "type": "string" }
-          },
-          "sourceFile": { "type": "string" }
-        },
-        "additionalProperties": false
-      }
+      "items": { "$ref": "./page-ocr-clan-wars.schema.json" }
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
## Summary
- add OCR point hotfix migration: `0006_clan_wars_ocr_points_hotfix.sql`
- add confirmed rewards hotfix migration: `0007_clan_wars_historical_rewards_hotfix.sql`
- add OCR-tool driven rewards migration: `0008_clan_wars_historical_rewards_from_ocr_tool.sql`
- add OCR toolkit under `tool/ocr-clan-results`
- update OCR toolkit to reusable single-page mode:
  - input is exactly one screenshot (`--image`)
  - input includes trusted clan participants JSON (`--participants-json`)
  - nicknames are auto-corrected to closest participant using string distance
  - validates `sum(playersOurs.points)` against OCR `totals.mine` and fails if diff > 1% (configurable)

## Canonical OCR import model
Import-focused model (no confidence/debug fields):
- `startsAt`, `endsAt`
- `hasPersonalRewards` (`0|1`)
- `opponentClanName`
- `totals` (`mine`, `opponent`)
- `playersOurs[]` (`rank`, `playerNick`, `points`)

Schemas:
- `tool/ocr-clan-results/schema/page-ocr-clan-wars.schema.json`
- `tool/ocr-clan-results/schema/run-report.schema.json`

## Verification
- `pnpm typecheck`
- `swift tool/ocr-clan-results/ocr-clan-results.swift --help`
- `swift tool/ocr-clan-results/ocr-clan-results.swift --image ~/Downloads/clanwars/10.04.25.jpg --participants-json /tmp/clan-members.json --output /tmp/page-ocr-clan-wars.json --max-mine-total-diff-ratio 0.05`
- `swift tool/ocr-clan-results/render-import-sql.swift /tmp/page-ocr-clan-wars.json /tmp/page-ocr-clan-wars.sql`
- `wrangler d1 migrations apply raid-sl-clan --remote` for `0006`, `0007`, `0008`
