### PR TITLE
ci: migrate GitHub Actions to v6 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,15 @@ jobs:
     env:
       PUBLIC_SITE_URL: ${{ vars.PUBLIC_SITE_URL }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.15.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm

--- a/apps/web/src/lib/i18n/i18n.ts
+++ b/apps/web/src/lib/i18n/i18n.ts
@@ -55,6 +55,7 @@ export const initI18n = async (language = resolveBootstrapLanguage()): Promise<t
         .init({
           lng: language,
           fallbackLng: DEFAULT_LANGUAGE,
+          showSupportNotice: false,
           interpolation: { escapeValue: false },
           defaultNS: "common",
           ns: ["common", "menu", "landing", "about", "dashboard", "units"],


### PR DESCRIPTION
## Summary
- bump actions/checkout from v4 to v6
- bump pnpm/action-setup from v4 to v6
- bump actions/setup-node from v4 to v6
- include i18n init option showSupportNotice: false

## Validation
- pnpm test
- pnpm typecheck
