### PR TITLE
fix(dashboard): align KT countdown anchor and timer display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Raid SL Clan Knowledge Base
 
 This file is a working knowledge base for agents and humans operating in this repository.
-It reflects repository state as of 2026-05-03 and should be corrected when code and docs drift.
+It reflects repository state as of 2026-05-04 and should be corrected when code and docs drift.
 
 ## Current Snapshot
 
@@ -13,6 +13,8 @@ It reflects repository state as of 2026-05-03 and should be corrected when code 
 - Repository-owned D1 migrations live in `platform/migrations`.
 - D1 schema migrations `0001_bootstrap.sql` and `0002_clan_competition_schema.sql` are applied for local development and the remote production database.
 - Remote preview D1 is currently not maintained as a required baseline and may intentionally lag behind production schema.
+- Countdown display contract is `days + hours` for `>= 24h` and `hours + minutes` for `< 24h` (no `0d` prefix).
+- KT countdown anchor is currently a biweekly Tuesday `09:00 UTC` start with `48h` duration; known personal rewards seed anchor is `2026-05-05T09:00:00.000Z`.
 - `pnpm typecheck` passes across the current workspace skeleton.
 - Tests exist and should be run from the workspace root with `pnpm test`.
 

--- a/apps/web/src/components/site/countdown-timer.test.tsx
+++ b/apps/web/src/components/site/countdown-timer.test.tsx
@@ -69,7 +69,7 @@ describe("CountdownTimer", () => {
       );
     });
 
-    expect(container.textContent).toContain("0m 2s");
+    expect(container.textContent).toContain("0h 0m");
 
     await act(async () => {
       vi.advanceTimersByTime(3000);

--- a/apps/web/src/lib/dashboard/countdown.test.ts
+++ b/apps/web/src/lib/dashboard/countdown.test.ts
@@ -13,7 +13,18 @@ describe("formatCountdown", () => {
     expect(text).toBe("2д 3ч");
   });
 
-  it("formats short countdown with localized minute/second units", () => {
+  it("formats sub-day countdown with localized hour/minute units", () => {
+    const text = formatCountdown(10 * 3_600_000 + 55 * 60_000 + 15_000, {
+      dayShort: "d",
+      hourShort: "h",
+      minuteShort: "m",
+      secondShort: "s"
+    });
+
+    expect(text).toBe("10h 55m");
+  });
+
+  it("keeps minute precision for under-one-hour countdowns", () => {
     const text = formatCountdown(2 * 60_000 + 15_000, {
       dayShort: "d",
       hourShort: "h",
@@ -21,13 +32,14 @@ describe("formatCountdown", () => {
       secondShort: "s"
     });
 
-    expect(text).toBe("2m 15s");
+    expect(text).toBe("0h 2m");
   });
 });
 
 describe("getNextTickMs", () => {
   it("returns adaptive tick cadence", () => {
     expect(getNextTickMs(1000 * 60 * 61)).toBe(60_000);
+    expect(getNextTickMs(1000 * 60 * 30)).toBe(60_000);
     expect(getNextTickMs(1000 * 59)).toBe(1_000);
   });
 });

--- a/apps/web/src/lib/dashboard/countdown.ts
+++ b/apps/web/src/lib/dashboard/countdown.ts
@@ -8,16 +8,16 @@ export type CountdownUnits = {
 export const formatCountdown = (msRemaining: number, units: CountdownUnits) => {
   const safe = Math.max(0, msRemaining);
 
-  if (safe >= 3_600_000) {
+  if (safe >= 86_400_000) {
     const days = Math.floor(safe / 86_400_000);
     const hours = Math.floor((safe % 86_400_000) / 3_600_000);
     return `${days}${units.dayShort} ${hours}${units.hourShort}`;
   }
 
-  const minutes = Math.floor(safe / 60_000);
-  const seconds = Math.floor((safe % 60_000) / 1_000);
-  return `${minutes}${units.minuteShort} ${seconds}${units.secondShort}`;
+  const hours = Math.floor(safe / 3_600_000);
+  const minutes = Math.floor((safe % 3_600_000) / 60_000);
+  return `${hours}${units.hourShort} ${minutes}${units.minuteShort}`;
 };
 
 export const getNextTickMs = (msRemaining: number) =>
-  msRemaining < 3_600_000 ? 1_000 : 60_000;
+  msRemaining < 60_000 ? 1_000 : 60_000;

--- a/docs/superpowers/specs/2026-05-03-clan-dashboard-mobile-first-design.md
+++ b/docs/superpowers/specs/2026-05-03-clan-dashboard-mobile-first-design.md
@@ -142,8 +142,8 @@ Behavior:
 
 - Input: target ISO datetime.
 - Output formatting:
-  - default: days + hours
-  - under 1 hour: minutes + seconds
+  - `>= 24h`: days + hours
+  - `< 24h`: hours + minutes (no `0d` prefix)
 - Adaptive tick cadence (do not rerender every second when unnecessary).
 - Emit one-shot `onTimerEnd` when crossing zero.
 - Stop internal interval after end event.
@@ -241,7 +241,7 @@ Recommended order:
 
 This order keeps the dashboard immediately useful while exposing data gaps explicitly instead of hiding them.
 
-## 14. Post-Merge Decisions (2026-05-03)
+## 14. Post-Merge Decisions (2026-05-03, updated 2026-05-04)
 
 The first production implementation was merged to `main` via PR #33 on 2026-05-03.
 
@@ -249,8 +249,8 @@ Documented decisions from implementation:
 
 - `Hydra` countdown anchor is fixed to weekly reset at Wednesday `08:00 UTC`.
 - `Chimera` countdown anchor is fixed to weekly reset at Thursday `11:30 UTC`.
-- `KT` countdown anchor is fixed to a biweekly cycle starting Tuesday `10:00 UTC`, event duration `48h`.
-- KT personal rewards schedule is currently seeded from known anchor start `2026-05-05T10:00:00.000Z` (`hasPersonalRewards = true` for that start).
+- `KT` countdown anchor is fixed to a biweekly cycle starting Tuesday `09:00 UTC`, event duration `48h`.
+- KT personal rewards schedule is currently seeded from known anchor start `2026-05-05T09:00:00.000Z` (`hasPersonalRewards = true` for that start).
 
 Review-driven technical decisions merged with the implementation:
 

--- a/docs/superpowers/specs/2026-05-03-i18next-localization-globalization-design.md
+++ b/docs/superpowers/specs/2026-05-03-i18next-localization-globalization-design.md
@@ -127,7 +127,7 @@ Use locale-aware `Intl.DateTimeFormat` with user timezone resolution (`Intl.Date
 
 1. Replace static unit suffixes (`d/h/m/s`) with localized units/messages.
 2. Prefer `Intl.RelativeTimeFormat` where semantics match.
-3. Keep current countdown update cadence; only localized rendering changes.
+3. Preserve countdown behavior contract from dashboard spec: `>= 24h` as `days + hours`, `< 24h` as `hours + minutes`, with adaptive cadence (`1m+` minute ticks, final minute second ticks).
 
 ## 9. Error Handling
 

--- a/packages/platform/src/dashboard/reset-anchors.ts
+++ b/packages/platform/src/dashboard/reset-anchors.ts
@@ -57,12 +57,12 @@ const chimeraResetAnchor: WeeklyUtcAnchorConfig = {
   minute: 30
 };
 
-const clanWarsInitialStartUtc = "2026-05-05T10:00:00.000Z";
+const clanWarsInitialStartUtc = "2026-05-05T09:00:00.000Z";
 const clanWarsIntervalMs = 14 * 24 * 60 * 60 * 1000;
 const clanWarsDurationMs = 48 * 60 * 60 * 1000;
 
 const clanWarsPersonalRewardsStarts = new Set<string>([
-  "2026-05-05T10:00:00.000Z"
+  "2026-05-05T09:00:00.000Z"
 ]);
 
 export const getNextHydraResetAnchorUtc = (nowIso: string) =>

--- a/packages/platform/test/reset-anchors.test.ts
+++ b/packages/platform/test/reset-anchors.test.ts
@@ -34,13 +34,13 @@ describe("dashboard reset anchors", () => {
     ).toBe("2026-05-08T20:45:00.000Z");
   });
 
-  it("uses Tuesday 10:00 UTC as clan wars start anchor and marks 2026-05-05 as personal rewards", () => {
+  it("uses Tuesday 09:00 UTC as clan wars start anchor and marks 2026-05-05 as personal rewards", () => {
     const state = getClanWarsAnchorStateUtc("2026-05-03T11:22:00.000Z");
 
     expect(state.targetKind).toBe("start");
-    expect(state.targetAt).toBe("2026-05-05T10:00:00.000Z");
-    expect(state.eventStartAt).toBe("2026-05-05T10:00:00.000Z");
-    expect(state.eventEndsAt).toBe("2026-05-07T10:00:00.000Z");
+    expect(state.targetAt).toBe("2026-05-05T09:00:00.000Z");
+    expect(state.eventStartAt).toBe("2026-05-05T09:00:00.000Z");
+    expect(state.eventEndsAt).toBe("2026-05-07T09:00:00.000Z");
     expect(state.hasPersonalRewards).toBe(true);
   });
 
@@ -48,10 +48,10 @@ describe("dashboard reset anchors", () => {
     const activeState = getClanWarsAnchorStateUtc("2026-05-06T12:00:00.000Z");
 
     expect(activeState.targetKind).toBe("reset");
-    expect(activeState.targetAt).toBe("2026-05-07T10:00:00.000Z");
+    expect(activeState.targetAt).toBe("2026-05-07T09:00:00.000Z");
 
-    const postEventState = getClanWarsAnchorStateUtc("2026-05-07T10:00:00.000Z");
+    const postEventState = getClanWarsAnchorStateUtc("2026-05-07T09:00:00.000Z");
     expect(postEventState.targetKind).toBe("start");
-    expect(postEventState.targetAt).toBe("2026-05-19T10:00:00.000Z");
+    expect(postEventState.targetAt).toBe("2026-05-19T09:00:00.000Z");
   });
 });


### PR DESCRIPTION
## Summary
- switch countdown display contract to `days+hours` for `>=24h` and `hours+minutes` for `<24h` to avoid `0d` output
- adjust KT biweekly anchor from `10:00 UTC` to `09:00 UTC` and update seeded personal-rewards start timestamp
- update repository specs/knowledge docs so behavior and documented anchors match the implementation

## Verification
- `pnpm test -- apps/web/src/lib/dashboard/countdown.test.ts apps/web/src/components/site/countdown-timer.test.tsx packages/platform/test/reset-anchors.test.ts`
- `pnpm typecheck`
